### PR TITLE
Fix reference to `luca`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The set of objects passed in the `deliver` call are called `locals` and are aval
 require 'hanami/mailer'
 
 User = Struct.new(:name, :username)
-user = User.new('Luca', 'jodosha')
+luca = User.new('Luca', 'jodosha')
 
 Hanami::Mailer.load!
 
@@ -110,7 +110,7 @@ class WelcomeMailer
   private
 
   def recipient
-    user.email
+    luca.email
   end
 end
 
@@ -120,7 +120,7 @@ InvoiceMailer.deliver(user: luca)
 The corresponding `erb` file:
 
 ```erb
-Hello <%= user.name %>!
+Hello <%= luca.name %>!
 ```
 
 ### Scope


### PR DESCRIPTION
When the mailer is called, you pass an instance called `luca`

    InvoiceMailer.deliver(user: luca)

In the rest of the documentation, instead, the instance is called `user`. I fixed the reference name and decided to go with `luca` to make the code more explicit as the following can be a little bit more confusing to beginners

    InvoiceMailer.deliver(user: user)