### PR TITLE
Fixes #45, make hanami mailer compatible with mail-2.6.4

### DIFF
--- a/test/delivery_test.rb
+++ b/test/delivery_test.rb
@@ -57,7 +57,9 @@ describe Hanami::Mailer do
         attachment.wont_be :multipart?
 
         attachment.filename.must_equal     'invoice.pdf'
-        attachment.content_type.must_equal 'application/pdf; charset=UTF-8; filename=invoice.pdf'
+
+        attachment.content_type.must_match 'application/pdf'
+        attachment.content_type.must_match 'filename=invoice.pdf'
       end
     end
 


### PR DESCRIPTION
In newer version of mail, greater than 2.6.4, the content type of
non-text types are no longer have charset parameter, see
https://github.com/mikel/mail/commit/f19204dcfa8c58647abf9126998b1a27b04ded1e

To maintain compatible between old and new version, we need to change
the way we assert content type. We should expect each part explicitly
in separated assertion, don't assert on the whole string.