### PR TITLE
Fixed wrong variable in .erb snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ InvoiceMailer.deliver(user: luca)
 The corresponding `erb` file:
 
 ```erb
-Hello <%= luca.name %>!
+Hello <%= user.name %>!
 ```
 
 ### Scope


### PR DESCRIPTION
Hey guys,

It seems to me that there is a bug in the README.

I think that the variable that is assigned in the .erb file is the Hash keys of the `deliver` method.