### PR TITLE
Let ArgumentError to bubble up when not related to mailer DSL missing data

### DIFF
--- a/lib/hanami/mailer.rb
+++ b/lib/hanami/mailer.rb
@@ -223,8 +223,9 @@ module Hanami
     # @api private
     def deliver
       mail.deliver
-    rescue ArgumentError
-      raise MissingDeliveryDataError
+    rescue ArgumentError => e
+      raise MissingDeliveryDataError if e.message =~ /An SMTP (To|From) address/
+      raise
     end
 
     protected

--- a/test/delivery_test.rb
+++ b/test/delivery_test.rb
@@ -14,12 +14,26 @@ describe Hanami::Mailer do
       mail.parts.first.charset.must_equal charset
     end
 
-    it "raises error when 'from' isn't specified" do
+    it "raises specific error when 'from' isn't specified" do
       -> { MissingFromMailer.deliver }.must_raise Hanami::Mailer::MissingDeliveryDataError
     end
 
-    it "raises error when 'to' isn't specified" do
+    it "raises specific error when 'to' isn't specified" do
       -> { MissingToMailer.deliver }.must_raise Hanami::Mailer::MissingDeliveryDataError
+    end
+
+    it "lets other errors to bubble up" do
+      mailer = CharsetMailer.new({})
+      mail   = Class.new do
+        def deliver
+          raise ArgumentError, "ouch"
+        end
+      end.new
+
+      mailer.stub(:mail, mail) do
+        exception = -> { mailer.deliver }.must_raise ArgumentError
+        exception.message.must_equal "ouch"
+      end
     end
 
     describe 'test delivery with hardcoded values' do

--- a/test/delivery_test.rb
+++ b/test/delivery_test.rb
@@ -22,6 +22,14 @@ describe Hanami::Mailer do
       -> { MissingToMailer.deliver }.must_raise Hanami::Mailer::MissingDeliveryDataError
     end
 
+    it "doesn't raise error when 'cc' is specified but 'to' isn't" do
+      CcOnlyMailer.deliver
+    end
+
+    it "doesn't raise error when 'bcc' is specified but 'to' isn't" do
+      BccOnlyMailer.deliver
+    end
+
     it "lets other errors to bubble up" do
       mailer = CharsetMailer.new({})
       mail   = Class.new do

--- a/test/dsl_test.rb
+++ b/test/dsl_test.rb
@@ -23,7 +23,7 @@ describe Hanami::Mailer do
     describe 'when no value is set' do
       it 'returns a set of templates' do
         template_formats = LazyMailer.templates.keys
-        template_formats.must_equal [:html, :txt]
+        template_formats.must_equal %i(html txt)
       end
 
       it 'returns only the template for the given format' do

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -35,6 +35,24 @@ class MissingToMailer
   subject 'Hello'
 end
 
+class CcOnlyMailer
+  include Hanami::Mailer
+  template 'missing'
+
+  cc      'recipient@example.com'
+  from    'sender@example.com'
+  subject 'Hello'
+end
+
+class BccOnlyMailer
+  include Hanami::Mailer
+  template 'missing'
+
+  bcc      'recipient@example.com'
+  from    'sender@example.com'
+  subject 'Hello'
+end
+
 User = Struct.new(:name, :email)
 
 class LazyMailer


### PR DESCRIPTION
When a mailer is fresh generated needs to be configured with `from`, `to`, `subject` DSL.

We used to catch the lack of these settings at the delivery time `WelcomeMailer.deliver`, by catching `ArgumentError` from `mail` gem.

Now it turns out, that the rescue clause is too "greedy", and it also catches `ArgumentError` raised by other gems.

---

One solution is to remove the rescue clause at all, but the exception message coming from `mail` doesn't give useful informations for `hanami-mailer` users:

```
"An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address."
```

We use different settings in the DSL.

---

The current solution is based on a match on that `mail` message: if it matches, it raises the specific exception (`Hanami::Mailer::MissingDeliveryDataError`), otherwise it lets the exception to bubble up. In this case, developers are able to read the original message.

---

/cc @hanami/core for review.