### PR TITLE
Add reply_to config to mailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ It supports a few options:
 ```ruby
 require 'hanami/mailer'
 
-Hanami::Maler.configure do
+Hanami::Mailer.configure do
   # Set the root path where to search for templates
   # Argument: String, Pathname, #to_pathname, defaults to the current directory
   #

--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ Hanami::Maler.configure do
   # Argument: Symbol
   # Argument: Hash, optional configurations
   delivery_method :stmp
+end
 ```
 
 ### Attachments

--- a/lib/hanami/mailer.rb
+++ b/lib/hanami/mailer.rb
@@ -283,11 +283,12 @@ module Hanami
     # rubocop:disable Metrics/AbcSize
     def build
       Mail.new.tap do |m|
-        m.from    = __dsl(:from)
-        m.to      = __dsl(:to)
-        m.cc      = __dsl(:cc)
-        m.bcc     = __dsl(:bcc)
-        m.subject = __dsl(:subject)
+        m.from     = __dsl(:from)
+        m.to       = __dsl(:to)
+        m.cc       = __dsl(:cc)
+        m.bcc      = __dsl(:bcc)
+        m.reply_to = __dsl(:reply_to)
+        m.subject  = __dsl(:subject)
 
         m.charset   = charset
         m.html_part = __part(:html)

--- a/lib/hanami/mailer/dsl.rb
+++ b/lib/hanami/mailer/dsl.rb
@@ -11,11 +11,12 @@ module Hanami
       # @api private
       def self.extended(base)
         base.class_eval do
-          @from    = nil
-          @to      = nil
-          @cc      = nil
-          @bcc     = nil
-          @subject = nil
+          @from     = nil
+          @to       = nil
+          @cc       = nil
+          @bcc      = nil
+          @reply_to = nil
+          @subject  = nil
         end
       end
 
@@ -316,6 +317,95 @@ module Hanami
           @bcc
         else
           @bcc = value
+        end
+      end
+
+      # Sets the reply_to for mail messages
+      #
+      # It accepts a hardcoded value as a string or array of strings.
+      # For dynamic values, you can specify a symbol that represents an instance
+      # method.
+      #
+      # This value is optional.
+      #
+      # When a value is given, it specifies the reply_to for the email.
+      # When a value is not given, it returns the reply_to of the email.
+      #
+      # This is part of a DSL, for this reason when this method is called with
+      # an argument, it will set the corresponding class variable. When
+      # called without, it will return the already set value, or the default.
+      #
+      # @overload reply_to(value)
+      #   Sets the reply_to
+      #   @param value [String, Array, Symbol] the hardcoded value or method name
+      #   @return [NilClass]
+      #
+      # @overload reply_to
+      #   Returns the reply_to
+      #   @return [String, Array, Symbol] the recipient
+      #
+      # @since 0.3.0
+      #
+      # @example Hardcoded value (String)
+      #   require 'hanami/mailer'
+      #
+      #   class WelcomeMailer
+      #     include Hanami::Mailer
+      #
+      #     to "user@example.com"
+      #     reply_to "other.user@example.com"
+      #   end
+      #
+      # @example Hardcoded value (Array)
+      #   require 'hanami/mailer'
+      #
+      #   class WelcomeMailer
+      #     include Hanami::Mailer
+      #
+      #     to ["user-1@example.com", "user-2@example.com"]
+      #     reply_to ["other.user-1@example.com", "other.user-2@example.com"]
+      #   end
+      #
+      # @example Method (Symbol)
+      #   require 'hanami/mailer'
+      #
+      #   class WelcomeMailer
+      #     include Hanami::Mailer
+      #     to "user@example.com"
+      #     reply_to :email_address
+      #
+      #     private
+      #
+      #     def email_address
+      #       user.email
+      #     end
+      #   end
+      #
+      #   other_user = User.new(name: 'L')
+      #   WelcomeMailer.deliver(user: other_user)
+      #
+      # @example Method that returns a collection of recipients
+      #   require 'hanami/mailer'
+      #
+      #   class WelcomeMailer
+      #     include Hanami::Mailer
+      #     to "user@example.com"
+      #     reply_to :recipients
+      #
+      #     private
+      #
+      #     def recipients
+      #       users.map(&:email)
+      #     end
+      #   end
+      #
+      #   other_users = [User.new(name: 'L'), User.new(name: 'MG')]
+      #   WelcomeMailer.deliver(users: other_users)
+      def reply_to(value = nil)
+        if value.nil?
+          @reply_to
+        else
+          @reply_to = value
         end
       end
 

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -84,10 +84,11 @@ end
 class WelcomeMailer
   include Hanami::Mailer
 
-  from 'noreply@sender.com'
-  to   ['noreply@recipient.com', 'owner@recipient.com']
-  cc   'cc@recipient.com'
-  bcc  'bcc@recipient.com'
+  from     'noreply@sender.com'
+  to       ['noreply@recipient.com', 'owner@recipient.com']
+  cc       'cc@recipient.com'
+  bcc      'bcc@recipient.com'
+  reply_to 'reply_to@recipient.com'
 
   subject 'Welcome'
 

--- a/spec/unit/hanami/mailer/delivery_spec.rb
+++ b/spec/unit/hanami/mailer/delivery_spec.rb
@@ -55,11 +55,12 @@ RSpec.describe Hanami::Mailer do
       end
 
       it 'sends the correct information' do
-        expect(@mail.from).to    eq(['noreply@sender.com'])
-        expect(@mail.to).to      eq(['noreply@recipient.com', 'owner@recipient.com'])
-        expect(@mail.cc).to      eq(['cc@recipient.com'])
-        expect(@mail.bcc).to     eq(['bcc@recipient.com'])
-        expect(@mail.subject).to eq('Welcome')
+        expect(@mail.from).to     eq(['noreply@sender.com'])
+        expect(@mail.to).to       eq(['noreply@recipient.com', 'owner@recipient.com'])
+        expect(@mail.cc).to       eq(['cc@recipient.com'])
+        expect(@mail.bcc).to      eq(['bcc@recipient.com'])
+        expect(@mail.reply_to).to eq(['reply_to@recipient.com'])
+        expect(@mail.subject).to  eq('Welcome')
       end
 
       it 'has the correct templates' do

--- a/spec/unit/hanami/mailer/dsl_spec.rb
+++ b/spec/unit/hanami/mailer/dsl_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Hanami::Mailer do
     describe 'when no value is set' do
       it 'returns a set of templates' do
         template_formats = LazyMailer.templates.keys
-        expect(template_formats).to eq(%i[html txt])
+        expect(template_formats).to match_array(%i[html txt])
       end
 
       it 'returns only the template for the given format' do


### PR DESCRIPTION
We wanted to set the `reply_to` email address in one of your emails and realized that this config is missing in hanami mailer. 

This PR adds the `reply_to` mail config.