### PR TITLE
adds support for specifying a MAIL FROM address

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ end.load!
 class WelcomeMailer
   include Hanami::Mailer
 
+  return_path 'bounce@sender.com'
   from 'noreply@sender.com'
   to   'noreply@recipient.com'
   cc   'cc@sender.com'

--- a/lib/hanami/mailer.rb
+++ b/lib/hanami/mailer.rb
@@ -284,6 +284,7 @@ module Hanami
     # rubocop:disable Metrics/AbcSize
     def build
       Mail.new.tap do |m|
+        m.return_path = __dsl(:return_path)
         m.from     = __dsl(:from)
         m.to       = __dsl(:to)
         m.cc       = __dsl(:cc)

--- a/lib/hanami/mailer/dsl.rb
+++ b/lib/hanami/mailer/dsl.rb
@@ -86,6 +86,63 @@ module Hanami
         end
       end
 
+      # Sets the MAIL FROM address for mail messages.
+      # This lets you specify a "bounce address" different from the sender
+      # address specified with `from`.
+      #
+      # It accepts a hardcoded value as a string, or a symbol that represents
+      # an instance method for more complex logic.
+      #
+      # This value is optional.
+      #
+      # When a value is given, specify the MAIL FROM address of the email
+      # Otherwise, it returns the MAIL FROM address of the email
+      #
+      # This is part of a DSL, for this reason when this method is called with
+      # an argument, it will set the corresponding class variable. When
+      # called without, it will return the already set value, or the default.
+      #
+      # @overload return_path(value)
+      #   Sets the MAIL FROM address
+      #   @param value [String, Symbol] the hardcoded value or method name
+      #   @return [NilClass]
+      #
+      # @overload return_path
+      #   Returns the MAIL FROM address
+      #   @return [String, Symbol] the MAIL FROM address
+      #
+      # @since 1.3.2
+      #
+      # @example Hardcoded value (String)
+      #   require 'hanami/mailer'
+      #
+      #   class WelcomeMailer
+      #     include Hanami::Mailer
+      #
+      #     return_path "bounce@example.com"
+      #   end
+      #
+      # @example Method (Symbol)
+      #   require 'hanami/mailer'
+      #
+      #   class WelcomeMailer
+      #     include Hanami::Mailer
+      #     return_path :bounce_address
+      #
+      #     private
+      #
+      #     def bounce_address
+      #       "bounce@example.com"
+      #     end
+      #   end
+      def return_path(value = nil)
+        if value.nil?
+          @return_path
+        else
+          @return_path = value
+        end
+      end
+
       # Sets the sender for mail messages
       #
       # It accepts a hardcoded value as a string, or a symbol that represents

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -84,6 +84,7 @@ end
 class WelcomeMailer
   include Hanami::Mailer
 
+  return_path 'bounce@sender.com'
   from     'noreply@sender.com'
   to       ['noreply@recipient.com', 'owner@recipient.com']
   cc       'cc@recipient.com'

--- a/spec/unit/hanami/mailer/delivery_spec.rb
+++ b/spec/unit/hanami/mailer/delivery_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe Hanami::Mailer do
       end
 
       it 'sends the correct information' do
+        expect(@mail.return_path).to eq('bounce@sender.com')
         expect(@mail.from).to     eq(['noreply@sender.com'])
         expect(@mail.to).to       eq(['noreply@recipient.com', 'owner@recipient.com'])
         expect(@mail.cc).to       eq(['cc@recipient.com'])


### PR DESCRIPTION
via the `return_path` dsl method, mirroring mail gem functionality.

the [mail gem will use the first address][envelope] supplied to `from` (apart from [other candidates][mail]) as the MAIL FROM address. this patch allows to specify a different address to receive bounces at.

[envelope]: https://github.com/mikel/mail/blob/aba0b5fd3a073fea1806eb3ac2aaf640941f7362/lib/mail/smtp_envelope.rb#L12
[mail]: https://github.com/mikel/mail/blob/aba0b5fd3a073fea1806eb3ac2aaf640941f7362/lib/mail/message.rb#L1051-L1073