### PR TITLE
Use published mail gem in preference to its dependencies

### DIFF
--- a/benchmark.rb
+++ b/benchmark.rb
@@ -4,7 +4,7 @@ require "bundler/setup"
 require "hanami/mailer"
 require "benchmark/ips"
 require "allocation_stats"
-require_relative "./examples/base"
+require_relative "examples/base"
 
 configuration = Hanami::Mailer::Configuration.new do |config|
   config.root            = "examples/base"

--- a/hanami-mailer.gemspec
+++ b/hanami-mailer.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata["rubygems_mfa_required"] = "true"
   spec.required_ruby_version = ">= 3.0"
 
-  spec.add_dependency "hanami-utils", "~> 2.1"
+  spec.add_dependency "hanami-utils", "~> 2.0"
   spec.add_dependency "tilt",         "~> 2.0", ">= 2.0.1"
   spec.add_dependency "mail",         "~> 2.8", ">= 2.8.1"
 

--- a/hanami-mailer.gemspec
+++ b/hanami-mailer.gemspec
@@ -22,14 +22,9 @@ Gem::Specification.new do |spec|
   spec.metadata["rubygems_mfa_required"] = "true"
   spec.required_ruby_version = ">= 3.0"
 
-  spec.add_dependency "hanami-utils", "~> 2.0.alpha"
+  spec.add_dependency "hanami-utils", "~> 2.1"
   spec.add_dependency "tilt",         "~> 2.0", ">= 2.0.1"
-  spec.add_dependency "mail",         "~> 2.7"
-
-  # FIXME: remove when https://github.com/mikel/mail/pull/1439 gets merged AND a new version of `mail` gets released
-  spec.add_dependency "net-smtp", "~> 0.3"
-  spec.add_dependency "net-pop",  "~> 0.1"
-  spec.add_dependency "net-imap", "~> 0.2"
+  spec.add_dependency "mail",         "~> 2.8", ">= 2.8.1"
 
   spec.add_development_dependency "bundler", ">= 1.6", "< 3"
   spec.add_development_dependency "rake",    "~> 13"


### PR DESCRIPTION
We were waiting for the `mail` gem to merge a pull request and release a
new version which has been done in version 2.8.1. This version has since
February been [available on rubygems.org](https://rubygems.org/gems/mail/versions/2.8.1).

I've also removed the `.alpha` suffix from the `hanami-utils` version
spec as it's not needed anymore.