### PR TITLE
Move test delivery state from class to instance

### DIFF
--- a/lib/hanami/mailer/delivery/test.rb
+++ b/lib/hanami/mailer/delivery/test.rb
@@ -7,22 +7,20 @@ module Hanami
       #
       # @api public
       class Test
-        class << self
-          # Returns all delivery results
-          #
-          # @return [Array<Delivery::Result>]
-          #
-          # @api public
-          def deliveries
-            @deliveries ||= []
-          end
+        # Returns all delivery results
+        #
+        # @return [Array<Delivery::Result>]
+        #
+        # @api public
+        def deliveries
+          @deliveries ||= []
+        end
 
-          # Clear all delivery results
-          #
-          # @api public
-          def clear
-            deliveries.clear
-          end
+        # Clear all delivery results
+        #
+        # @api public
+        def clear
+          deliveries.clear
         end
 
         # Deliver a message by storing a result in memory
@@ -33,7 +31,7 @@ module Hanami
         # @api private
         def call(message)
           result = Result.new(message: message)
-          self.class.deliveries << result
+          deliveries << result
           result
         end
 

--- a/spec/integration/delivery_result_spec.rb
+++ b/spec/integration/delivery_result_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe "Delivery results" do
       user = {name: "Bob", email: "bob@example.com"}
       mailer.deliver(user: user)
 
-      expect(Hanami::Mailer::Delivery::Test.deliveries.size).to eq(1)
-      result = Hanami::Mailer::Delivery::Test.deliveries.first
+      expect(mailer.delivery_method.deliveries.size).to eq(1)
+      result = mailer.delivery_method.deliveries.first
       expect(result).to be_a(Hanami::Mailer::Delivery::Result)
       expect(result.message.to).to eq(["bob@example.com"])
     end
@@ -82,7 +82,7 @@ RSpec.describe "Delivery results" do
       mailer.deliver(user: {name: "Bob", email: "bob@example.com"})
       mailer.deliver(user: {name: "Charlie", email: "charlie@example.com"})
 
-      messages = Hanami::Mailer::Delivery::Test.deliveries.map(&:message)
+      messages = mailer.delivery_method.deliveries.map(&:message)
       expect(messages.map { |m| m.to.first }).to eq([
         "alice@example.com",
         "bob@example.com",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,9 +25,4 @@ RSpec.configure do |config|
 
   config.order = :random
   Kernel.srand config.seed
-
-  # Clear test deliveries before each example
-  config.before do
-    Hanami::Mailer::Delivery::Test.clear
-  end
 end

--- a/spec/unit/delivery/test_spec.rb
+++ b/spec/unit/delivery/test_spec.rb
@@ -4,29 +4,27 @@ RSpec.describe Hanami::Mailer::Delivery::Test do
   let(:message) { minimal_message }
   let(:delivery) { described_class.new }
 
-  describe ".deliveries" do
+  describe "#deliveries" do
     it "is empty after clear" do
-      described_class.clear
+      delivery.clear
 
-      expect(described_class.deliveries).to be_empty
+      expect(delivery.deliveries).to be_empty
     end
 
     it "accumulates results across multiple calls" do
-      described_class.clear
-
       delivery.call(message)
       delivery.call(message)
 
-      expect(described_class.deliveries.size).to eq(2)
+      expect(delivery.deliveries.size).to eq(2)
     end
   end
 
-  describe ".clear" do
+  describe "#clear" do
     it "empties the deliveries collection" do
       delivery.call(message)
-      described_class.clear
+      delivery.clear
 
-      expect(described_class.deliveries).to be_empty
+      expect(delivery.deliveries).to be_empty
     end
   end
 
@@ -56,10 +54,10 @@ RSpec.describe Hanami::Mailer::Delivery::Test do
       expect(result.error).to be_nil
     end
 
-    it "stores the result in the class-level deliveries" do
+    it "stores the result in the instance-level deliveries" do
       result = delivery.call(message)
 
-      expect(described_class.deliveries).to include(result)
+      expect(delivery.deliveries).to include(result)
     end
   end
 


### PR DESCRIPTION
`Delivery::Test` storing its results in class-level state meant this leaked across tests. It also would prevent us from having isolated per-slice test delivery objects when we integrate Hanami Mailer with Hanami apps.

To address this, move this state to the instance level, and make it manageable via `#deliveries` and `#clear` instance methods.