### PR TITLE
Make view class configurable

### DIFF
--- a/lib/hanami/mailer/view_integration.rb
+++ b/lib/hanami/mailer/view_integration.rb
@@ -13,6 +13,9 @@ module Hanami
           # Prepend the initializer module to wrap initialization
           prepend PrependedMethods
 
+          # Add class-level methods, including the lazily-built, memoized default view
+          extend ClassMethods
+
           # Whether to automatically build views from exposures
           # Set to false to disable automatic view integration behavior
           setting :integrate_view, default: true
@@ -40,15 +43,38 @@ module Hanami
         end
       end
 
-      # Internal module for prepending initialize and render behavior.
+      # Class-level methods added to mailer classes when Hanami::View is available.
+      #
+      # @api private
+      module ClassMethods
+        # The auto-built default view for this mailer class.
+        #
+        # Built lazily on first access (the first render) and memoized, since it depends only on
+        # class-level state (config, exposures, class name) and is identical for every instance.
+        # Returns nil when view integration is disabled or no usable template paths are configured.
+        #
+        # Note: because the view is memoized on first render, later changes to view-related
+        # config or exposures are not reflected. Mailer classes are configured once at definition
+        # time, so this is intentional.
+        #
+        # @api private
+        def default_view
+          return @default_view if defined?(@default_view)
+
+          @default_view = config.integrate_view ? DefaultViewBuilder.call(self) : nil
+        end
+      end
+
+      # Internal module for prepending view and render behavior.
       # Wraps the base class to provide automatic view building and
       # per-format template error handling.
       #
       # @api private
       module PrependedMethods
-        def initialize(view: nil, **)
-          view ||= DefaultViewBuilder.call(self) if self.class.config.integrate_view
-          super
+        # The view used for rendering: a per-instance override passed to the constructor, falling
+        # back to the mailer class's lazily-built, memoized default view.
+        def view
+          @view || self.class.default_view
         end
 
         # Renders HTML and text bodies, handling missing templates per format.
@@ -78,25 +104,25 @@ module Hanami
       class DefaultViewBuilder
         class << self
           # Builds a default view from exposures if Hanami::View is available.
-          def call(mailer)
-            view_class = mailer.class.config.view_class || Hanami::View
+          def call(mailer_class)
+            view_class = mailer_class.config.view_class || Hanami::View
 
             # A view needs paths to find its templates. These may be configured on the mailer, or
             # inherited from an already-configured `view_class` (e.g. within a Hanami app).
-            paths = mailer.class.config.paths
+            paths = mailer_class.config.paths
             if (paths.nil? || paths.empty?) && view_class.respond_to?(:config)
               paths = view_class.config.paths
             end
             return nil if paths.nil? || paths.empty?
 
-            template = mailer.class.config.template
-            template ||= inferred_template(mailer)
+            template = mailer_class.config.template
+            template ||= inferred_template(mailer_class)
 
             build_view_class(
               view_class: view_class,
               template: template,
-              exposures: mailer.class.exposures,
-              config: mailer.class.config
+              exposures: mailer_class.exposures,
+              config: mailer_class.config
             )
           end
 
@@ -106,10 +132,10 @@ module Hanami
           #
           # @example
           #   Mailers::WelcomeMailer -> "mailers/welcome_mailer"
-          def inferred_template(mailer)
-            return nil unless mailer.class.name
+          def inferred_template(mailer_class)
+            return nil unless mailer_class.name
 
-            mailer.class.name
+            mailer_class.name
               .gsub("::", "/")
               .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
               .gsub(/([a-z\d])([A-Z])/, '\1_\2')

--- a/lib/hanami/mailer/view_integration.rb
+++ b/lib/hanami/mailer/view_integration.rb
@@ -17,6 +17,12 @@ module Hanami
           # Set to false to disable automatic view integration behavior
           setting :integrate_view, default: true
 
+          # The base class used when building the mailer's view. Defaults to Hanami::View, but
+          # may be set to an already-configured view class (such as a view class within a Hanami
+          # app), in which case the built view inherits that class's configuration — context,
+          # parts, scopes, paths, helpers and so on.
+          setting :view_class, default: Hanami::View
+
           # Copy all settings from Hanami::View to support default view integration.
           # This allows mailers to configure view-related settings (like layouts_dir,
           # default_format, inflector, etc.) without having to manually redefine them.
@@ -73,13 +79,21 @@ module Hanami
         class << self
           # Builds a default view from exposures if Hanami::View is available.
           def call(mailer)
-            return nil if mailer.class.exposures.empty? && mailer.class.config.paths.empty?
+            view_class = mailer.class.config.view_class || Hanami::View
+
+            # A view needs paths to find its templates. These may be configured on the mailer, or
+            # inherited from an already-configured `view_class` (e.g. within a Hanami app).
+            paths = mailer.class.config.paths
+            if (paths.nil? || paths.empty?) && view_class.respond_to?(:config)
+              paths = view_class.config.paths
+            end
+            return nil if paths.nil? || paths.empty?
 
             template = mailer.class.config.template
             template ||= inferred_template(mailer)
 
             build_view_class(
-              paths: mailer.class.config.paths,
+              view_class: view_class,
               template: template,
               exposures: mailer.class.exposures,
               config: mailer.class.config
@@ -104,34 +118,35 @@ module Hanami
 
           # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
 
-          # Builds a Hanami::View instance from mailer configuration.
-          def build_view_class(paths:, template:, exposures:, config:)
-            view_paths = paths
+          # Builds a Hanami::View instance from the mailer's configuration.
+          #
+          # The view is a subclass of the mailer's configured `view_class`, so it inherits that
+          # class's configuration. Only view settings the mailer has *explicitly* configured are
+          # applied as overrides, leaving an already-configured base class (such as a Hanami app's
+          # view) to provide its context, parts, scopes and helpers by inheritance. A standalone
+          # mailer (whose `view_class` is the unconfigured `Hanami::View`) still drives its own
+          # view via these overrides.
+          def build_view_class(view_class:, template:, exposures:, config:)
             view_template = template
             view_exposures = exposures
             mailer_config = config
 
-            # paths is required by Hanami::View - return nil if not configured
-            return nil if view_paths.nil? || view_paths.empty?
-
-            # View settings we configure explicitly below — don't overwrite them
-            explicitly_configured = %i[paths template layout]
-
-            view_class = Class.new(Hanami::View) do
-              self.config.paths = view_paths
-              self.config.template = view_template
-              self.config.layout = false
-
-              # Copy remaining view settings from mailer config
+            built = Class.new(view_class) do
               Hanami::View.config._settings.each do |setting_def|
-                next if explicitly_configured.include?(setting_def.name)
-                next unless mailer_config.respond_to?(setting_def.name)
+                name = setting_def.name
 
-                self.config.public_send(
-                  :"#{setting_def.name}=",
-                  mailer_config.public_send(setting_def.name)
-                )
+                # `template` and `layout` are handled explicitly below.
+                next if name == :template || name == :layout
+                next unless mailer_config.respond_to?(name)
+                next unless mailer_config.configured?(name)
+
+                self.config.public_send(:"#{name}=", mailer_config.public_send(name))
               end
+
+              # Mailers do not use a layout by default, but one may be configured.
+              self.config.layout = mailer_config.configured?(:layout) ? mailer_config.layout : false
+
+              self.config.template = view_template if view_template
 
               view_exposures.each do |name, exposure|
                 if exposure.proc
@@ -142,7 +157,7 @@ module Hanami
               end
             end
 
-            view_class.new
+            built.new
           end
           # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity
         end

--- a/spec/integration/view_class_spec.rb
+++ b/spec/integration/view_class_spec.rb
@@ -1,0 +1,274 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+RSpec.describe "Configurable view_class" do
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @templates_dir = Pathname(dir)
+      example.run
+    end
+  end
+
+  let(:templates_dir) { @templates_dir }
+
+  def write(path, content)
+    templates_dir.join(File.dirname(path)).mkpath
+    File.write(templates_dir.join(path), content)
+  end
+
+  describe "default" do
+    let(:mailer_class) { Class.new(Hanami::Mailer) }
+
+    it "defaults to Hanami::View" do
+      expect(mailer_class.config.view_class).to be(Hanami::View)
+    end
+
+    it "is inherited by subclasses" do
+      child = Class.new(mailer_class)
+
+      expect(child.config.view_class).to be(Hanami::View)
+    end
+  end
+
+  describe "building from a configured view_class" do
+    before do
+      write "welcome_mailer.html.erb", "<h1>Welcome <%= name %></h1>"
+      write "welcome_mailer.text.erb", "Welcome <%= name %>"
+    end
+
+    let(:base_view_class) {
+      dir = templates_dir
+      Class.new(Hanami::View) {
+        config.paths = [dir]
+      }
+    }
+
+    let(:mailer_class) {
+      view = base_view_class
+      Class.new(Hanami::Mailer) {
+        config.view_class = view
+        config.template = "welcome_mailer"
+
+        from "noreply@example.com"
+        to "user@example.com"
+        subject "Welcome"
+
+        expose :name
+      }
+    }
+
+    let(:mailer) { mailer_class.new }
+
+    it "builds the view as a subclass of the configured view_class" do
+      expect(mailer.view).to be_a(base_view_class)
+    end
+
+    it "inherits the base view's paths so no paths need to be set on the mailer" do
+      expect(mailer_class.config.paths).to be_empty
+      expect(mailer.view).not_to be_nil
+    end
+
+    it "renders using the inherited paths" do
+      result = mailer.deliver(name: "Alice")
+
+      expect(result.message.html_body).to include("<h1>Welcome Alice</h1>")
+      expect(result.message.text_body).to include("Welcome Alice")
+    end
+
+    it "applies the mailer's exposures on top of the inherited configuration" do
+      result = mailer.deliver(name: "Bob")
+
+      expect(result.message.html_body).to include("Bob")
+    end
+
+    it "does not mutate the configured view_class" do
+      mailer.view
+
+      expect(base_view_class.config.template).to be_nil
+      expect(base_view_class.exposures.exposures).to be_empty
+    end
+  end
+
+  describe "inheriting view configuration" do
+    before do
+      write "welcome_mailer.html.erb", "<h1><%= greeting %></h1>"
+    end
+
+    let(:context_class) {
+      Class.new(Hanami::View::Context) do
+        def greeting
+          "Hello from context"
+        end
+      end
+    }
+
+    let(:base_view_class) {
+      dir = templates_dir
+      ctx = context_class
+      Class.new(Hanami::View) {
+        config.paths = [dir]
+        config.default_context = ctx.new
+        config.default_format = :html
+      }
+    }
+
+    let(:mailer_class) {
+      view = base_view_class
+      Class.new(Hanami::Mailer) {
+        config.view_class = view
+        config.template = "welcome_mailer"
+
+        from "noreply@example.com"
+        to "user@example.com"
+        subject "Welcome"
+      }
+    }
+
+    it "inherits the base view's context" do
+      result = mailer_class.new.deliver
+
+      expect(result.message.html_body).to include("Hello from context")
+    end
+
+    it "inherits other view settings such as default_format" do
+      expect(mailer_class.new.view.config.default_format).to eq(:html)
+    end
+  end
+
+  describe "mailer overrides take precedence over the base view's configuration" do
+    before do
+      write "welcome_mailer.html.erb", "<h1>Body</h1>"
+    end
+
+    let(:base_view_class) {
+      dir = templates_dir
+      Class.new(Hanami::View) {
+        config.paths = [dir]
+        config.default_format = :text
+      }
+    }
+
+    let(:mailer_class) {
+      view = base_view_class
+      Class.new(Hanami::Mailer) {
+        config.view_class = view
+        config.default_format = :html
+        config.template = "welcome_mailer"
+
+        from "noreply@example.com"
+        to "user@example.com"
+        subject "Welcome"
+      }
+    }
+
+    it "uses the mailer's explicitly configured setting" do
+      expect(mailer_class.new.view.config.default_format).to eq(:html)
+    end
+
+    it "leaves the base view's configuration untouched" do
+      mailer_class.new.view
+
+      expect(base_view_class.config.default_format).to eq(:text)
+    end
+  end
+
+  describe "explicit mailer paths override the base view's paths" do
+    before do
+      write "mailer_dir/welcome_mailer.html.erb", "<p>From mailer dir</p>"
+      write "base_dir/welcome_mailer.html.erb", "<p>From base dir</p>"
+    end
+
+    let(:base_view_class) {
+      dir = templates_dir
+      Class.new(Hanami::View) {
+        config.paths = [dir.join("base_dir")]
+      }
+    }
+
+    let(:mailer_class) {
+      dir = templates_dir
+      view = base_view_class
+      Class.new(Hanami::Mailer) {
+        config.view_class = view
+        config.paths = [dir.join("mailer_dir")]
+        config.template = "welcome_mailer"
+
+        from "noreply@example.com"
+        to "user@example.com"
+        subject "Welcome"
+      }
+    }
+
+    it "renders from the mailer's paths" do
+      result = mailer_class.new.deliver
+
+      expect(result.message.html_body).to include("From mailer dir")
+    end
+  end
+
+  describe "layout" do
+    before do
+      write "welcome_mailer.html.erb", "BODY"
+      write "layouts/app.html.erb", "LAYOUT[<%= yield %>]"
+    end
+
+    let(:base_view_class) {
+      dir = templates_dir
+      Class.new(Hanami::View) {
+        config.paths = [dir]
+        config.layout = "app"
+        config.default_format = :html
+      }
+    }
+
+    it "does not use the base view's layout unless the mailer configures one" do
+      view = base_view_class
+      mailer_class = Class.new(Hanami::Mailer) {
+        config.view_class = view
+        config.template = "welcome_mailer"
+
+        from "noreply@example.com"
+        to "user@example.com"
+        subject "Welcome"
+      }
+
+      result = mailer_class.new.deliver
+
+      expect(result.message.html_body).to eq("BODY")
+    end
+
+    it "uses a layout the mailer configures explicitly" do
+      view = base_view_class
+      mailer_class = Class.new(Hanami::Mailer) {
+        config.view_class = view
+        config.layout = "app"
+        config.template = "welcome_mailer"
+
+        from "noreply@example.com"
+        to "user@example.com"
+        subject "Welcome"
+      }
+
+      result = mailer_class.new.deliver
+
+      expect(result.message.html_body).to eq("LAYOUT[BODY]")
+    end
+  end
+
+  describe "without paths on the mailer or the view_class" do
+    let(:mailer_class) {
+      Class.new(Hanami::Mailer) {
+        from "noreply@example.com"
+        to "user@example.com"
+        subject "No view"
+
+        expose :name
+      }
+    }
+
+    it "does not build a view" do
+      expect(mailer_class.new.view).to be_nil
+    end
+  end
+end

--- a/spec/integration/view_integration_spec.rb
+++ b/spec/integration/view_integration_spec.rb
@@ -63,6 +63,30 @@ RSpec.describe "View integration" do
         expect(result.message.html_body).to include("Bob")
         expect(result.message.text_body).to include("Bob")
       end
+
+      it "builds the default view once per class and shares it across instances" do
+        expect(mailer_class.new.view).to be(mailer_class.new.view)
+      end
+
+      it "memoizes the default view on the class" do
+        expect(mailer_class.default_view).to be(mailer_class.default_view)
+        expect(mailer.view).to be(mailer_class.default_view)
+      end
+
+      it "builds a distinct default view per subclass" do
+        child_class = Class.new(mailer_class) { subject "Child" }
+
+        expect(child_class.default_view).not_to be(mailer_class.default_view)
+      end
+
+      it "lets a per-instance view: override win without using the class default" do
+        custom_view = Object.new
+
+        instance = mailer_class.new(view: custom_view)
+
+        expect(instance.view).to be(custom_view)
+        expect(instance.view).not_to be(mailer_class.default_view)
+      end
     end
 
     describe "exposures passed to view" do


### PR DESCRIPTION
Allow the mailer's view class to be configured, instead of just being hard-coded to `Hanami::View`. This means that in Hanami apps, the mailer integration can configure the app/slice base view as the mailer view class, which means all the app's standard view affordances are present in mailer views too.

While here, build a mailer's view class only once per class. Previously, we would run `DefaultViewBuilder.call` on every mailer instantiation, building a new anonymous `Hanami::View` subclass _and_ instance each time. The view class depended only on class-level state (config, exposures, class name), so it was identical for every instance. Now we build the view class lazily on first render, and memoize it for future instances.