### PR TITLE
Fix attachments breaking email body rendering (#78)

### DIFF
--- a/lib/hanami/mailer/delivery/smtp.rb
+++ b/lib/hanami/mailer/delivery/smtp.rb
@@ -58,7 +58,6 @@ module Hanami
           mail
         end
 
-        # Build a Mail::Message with addresses, subject, charset and custom headers
         def build_mail(message)
           # Use local variables to avoid shadowing Mail DSL methods
           from_addr = message.from
@@ -66,26 +65,23 @@ module Hanami
           cc_addr = message.cc
           bcc_addr = message.bcc
           reply_to_addr = message.reply_to
+          return_path_addr = message.return_path
           subject_text = message.subject
+          charset_value = message.charset
 
-          mail = Mail.new do
+          Mail.new do
             from from_addr
             to to_addr if to_addr
             cc cc_addr if cc_addr
             bcc bcc_addr if bcc_addr
             reply_to reply_to_addr if reply_to_addr
+            return_path return_path_addr if return_path_addr
             subject subject_text
+            self.charset = charset_value
+            message.headers.each { |key, value| self[key] = value }
           end
-
-          # return_path is not part of the Mail DSL block
-          mail.return_path = message.return_path if message.return_path
-          mail.charset = message.charset
-          message.headers.each { |key, value| mail[key] = value }
-
-          mail
         end
 
-        # Set the body content on the mail
         def assign_body(mail, message)
           return assign_single_body(mail, message) unless message.html_body && message.text_body
 
@@ -102,7 +98,6 @@ module Hanami
           end
         end
 
-        # Set a single (text-only or html-only) body inline on the mail
         def assign_single_body(mail, message)
           if message.html_body
             mail.content_type "text/html; charset=#{message.charset}"
@@ -113,7 +108,6 @@ module Hanami
           end
         end
 
-        # Build a multipart/alternative part wrapping the text and HTML bodies
         def alternative_part(message)
           Mail::Part.new.tap do |part|
             part.content_type "multipart/alternative"
@@ -122,7 +116,6 @@ module Hanami
           end
         end
 
-        # Build a single body part of the given MIME type
         def body_part(mime_type, content, charset)
           Mail::Part.new do
             content_type "#{mime_type}; charset=#{charset}"
@@ -130,7 +123,6 @@ module Hanami
           end
         end
 
-        # Add the message's attachments to the mail
         def add_attachments(mail, message)
           message.attachments.each do |attachment|
             if attachment.inline?

--- a/lib/hanami/mailer/delivery/smtp.rb
+++ b/lib/hanami/mailer/delivery/smtp.rb
@@ -91,7 +91,7 @@ module Hanami
           # Assigning html_part/text_part directly would leave a flat
           # multipart/alternative with the attachments as siblings of the bodies.
           if message.attachments.any?
-            mail.add_part(alternative_part(message))
+            mail.add_part(alternative_body_part(message))
           else
             mail.text_part = body_part("text/plain", message.text_body, message.charset)
             mail.html_part = body_part("text/html", message.html_body, message.charset)
@@ -108,7 +108,7 @@ module Hanami
           end
         end
 
-        def alternative_part(message)
+        def alternative_body_part(message)
           Mail::Part.new.tap do |part|
             part.content_type "multipart/alternative"
             part.text_part = body_part("text/plain", message.text_body, message.charset)

--- a/lib/hanami/mailer/delivery/smtp.rb
+++ b/lib/hanami/mailer/delivery/smtp.rb
@@ -44,8 +44,6 @@ module Hanami
 
         private
 
-        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-
         # Convert a Hanami::Mailer::Message to a Mail::Message
         #
         # @param message [Message] the message to convert
@@ -53,15 +51,22 @@ module Hanami
         def to_mail(message)
           require "mail"
 
+          mail = build_mail(message)
+          assign_body(mail, message)
+          add_attachments(mail, message)
+
+          mail
+        end
+
+        # Build a Mail::Message with addresses, subject, charset and custom headers
+        def build_mail(message)
           # Use local variables to avoid shadowing Mail DSL methods
           from_addr = message.from
           to_addr = message.to
           cc_addr = message.cc
           bcc_addr = message.bcc
           reply_to_addr = message.reply_to
-          return_path_addr = message.return_path
           subject_text = message.subject
-          charset_value = message.charset
 
           mail = Mail.new do
             from from_addr
@@ -72,36 +77,61 @@ module Hanami
             subject subject_text
           end
 
-          # Set return_path separately as it's not part of the Mail DSL block
-          mail.return_path = return_path_addr if return_path_addr
+          # return_path is not part of the Mail DSL block
+          mail.return_path = message.return_path if message.return_path
+          mail.charset = message.charset
+          message.headers.each { |key, value| mail[key] = value }
 
-          mail.charset = charset_value
+          mail
+        end
 
-          # Add custom headers
-          message.headers.each do |key, value|
-            mail[key] = value
+        # Set the body content on the mail
+        def assign_body(mail, message)
+          return assign_single_body(mail, message) unless message.html_body && message.text_body
+
+          # When attachments are present, the bodies must be wrapped in their own
+          # multipart/alternative part so Mail produces the correct nested structure:
+          # multipart/mixed > [multipart/alternative > [text, html], attachment].
+          # Assigning html_part/text_part directly would leave a flat
+          # multipart/alternative with the attachments as siblings of the bodies.
+          if message.attachments.any?
+            mail.add_part(alternative_part(message))
+          else
+            mail.text_part = body_part("text/plain", message.text_body, message.charset)
+            mail.html_part = body_part("text/html", message.html_body, message.charset)
           end
+        end
 
-          # Set body content
-          if message.html_body && message.text_body
-            mail.html_part = Mail::Part.new do
-              content_type "text/html; charset=#{charset_value}"
-              body message.html_body
-            end
-
-            mail.text_part = Mail::Part.new do
-              content_type "text/plain; charset=#{charset_value}"
-              body message.text_body
-            end
-          elsif message.html_body
-            mail.content_type "text/html; charset=#{charset_value}"
+        # Set a single (text-only or html-only) body inline on the mail
+        def assign_single_body(mail, message)
+          if message.html_body
+            mail.content_type "text/html; charset=#{message.charset}"
             mail.body = message.html_body
           elsif message.text_body
-            mail.content_type "text/plain; charset=#{charset_value}"
+            mail.content_type "text/plain; charset=#{message.charset}"
             mail.body = message.text_body
           end
+        end
 
-          # Add attachments
+        # Build a multipart/alternative part wrapping the text and HTML bodies
+        def alternative_part(message)
+          Mail::Part.new.tap do |part|
+            part.content_type "multipart/alternative"
+            part.text_part = body_part("text/plain", message.text_body, message.charset)
+            part.html_part = body_part("text/html", message.html_body, message.charset)
+          end
+        end
+
+        # Build a single body part of the given MIME type
+        def body_part(mime_type, content, charset)
+          Mail::Part.new do
+            content_type "#{mime_type}; charset=#{charset}"
+            body content
+          end
+        end
+
+        # Add the message's attachments to the mail
+        def add_attachments(mail, message)
           message.attachments.each do |attachment|
             if attachment.inline?
               mail.attachments.inline[attachment.filename] = {
@@ -116,10 +146,7 @@ module Hanami
               }
             end
           end
-
-          mail
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       end
     end
   end

--- a/lib/hanami/mailer/delivery/smtp.rb
+++ b/lib/hanami/mailer/delivery/smtp.rb
@@ -86,10 +86,7 @@ module Hanami
           if message.html_body && message.text_body
             assign_alternative_body(mail, message)
           elsif message.attachments.any?
-            # A single body must be added as a part rather than via #content_type,
-            # otherwise Mail pins the message as non-multipart and silently drops
-            # the body once the attachment is added.
-            mail.add_part(single_body_part(message))
+            assign_single_body_part(mail, message)
           else
             assign_single_body(mail, message)
           end
@@ -109,12 +106,11 @@ module Hanami
           end
         end
 
-        def single_body_part(message)
-          if message.html_body
-            body_part("text/html", message.html_body, message.charset)
-          else
-            body_part("text/plain", message.text_body, message.charset)
-          end
+        def assign_single_body_part(mail, message)
+          # A single body must be added as a part rather than via #content_type,
+          # otherwise Mail pins the message as non-multipart and silently drops
+          # the body once the attachment is added.
+          mail.add_part(single_body_part(message))
         end
 
         def assign_single_body(mail, message)
@@ -132,6 +128,14 @@ module Hanami
             part.content_type "multipart/alternative"
             part.text_part = body_part("text/plain", message.text_body, message.charset)
             part.html_part = body_part("text/html", message.html_body, message.charset)
+          end
+        end
+
+        def single_body_part(message)
+          if message.html_body
+            body_part("text/html", message.html_body, message.charset)
+          else
+            body_part("text/plain", message.text_body, message.charset)
           end
         end
 

--- a/lib/hanami/mailer/delivery/smtp.rb
+++ b/lib/hanami/mailer/delivery/smtp.rb
@@ -83,8 +83,19 @@ module Hanami
         end
 
         def assign_body(mail, message)
-          return assign_single_body(mail, message) unless message.html_body && message.text_body
+          if message.html_body && message.text_body
+            assign_alternative_body(mail, message)
+          elsif message.attachments.any?
+            # A single body must be added as a part rather than via #content_type,
+            # otherwise Mail pins the message as non-multipart and silently drops
+            # the body once the attachment is added.
+            mail.add_part(single_body_part(message))
+          else
+            assign_single_body(mail, message)
+          end
+        end
 
+        def assign_alternative_body(mail, message)
           # When attachments are present, the bodies must be wrapped in their own
           # multipart/alternative part so Mail produces the correct nested structure:
           # multipart/mixed > [multipart/alternative > [text, html], attachment].
@@ -95,6 +106,14 @@ module Hanami
           else
             mail.text_part = body_part("text/plain", message.text_body, message.charset)
             mail.html_part = body_part("text/html", message.html_body, message.charset)
+          end
+        end
+
+        def single_body_part(message)
+          if message.html_body
+            body_part("text/html", message.html_body, message.charset)
+          else
+            body_part("text/plain", message.text_body, message.charset)
           end
         end
 

--- a/spec/unit/delivery/smtp_spec.rb
+++ b/spec/unit/delivery/smtp_spec.rb
@@ -79,5 +79,39 @@ RSpec.describe Hanami::Mailer::Delivery::SMTP do
         expect(result.error.message).to include("Authentication failed")
       end
     end
+
+    context "when the message has both bodies and an attachment" do
+      let(:message) do
+        Hanami::Mailer::Message.new(
+          from: "noreply@example.com",
+          to: "user@example.com",
+          subject: "SMTP test",
+          html_body: "<h1>Hi</h1>",
+          text_body: "Hi",
+          attachments: [
+            Hanami::Mailer::Attachment.new(
+              filename: "invoice.pdf",
+              content: "%PDF-1.4 fake",
+              content_type: "application/pdf"
+            )
+          ]
+        )
+      end
+
+      let(:mail) { smtp_delivery.call(message).response }
+
+      it "nests the bodies in a multipart/alternative under multipart/mixed" do
+        expect(mail.mime_type).to eq("multipart/mixed")
+
+        alternative = mail.parts.find { |part| part.mime_type == "multipart/alternative" }
+        expect(alternative).not_to be_nil
+        expect(alternative.parts.map(&:mime_type)).to contain_exactly("text/plain", "text/html")
+      end
+
+      it "keeps the attachment as a sibling of the multipart/alternative" do
+        expect(mail.parts.map(&:mime_type)).to contain_exactly("multipart/alternative", "application/pdf")
+        expect(mail.attachments.map(&:filename)).to eq(["invoice.pdf"])
+      end
+    end
   end
 end

--- a/spec/unit/delivery/smtp_spec.rb
+++ b/spec/unit/delivery/smtp_spec.rb
@@ -218,6 +218,41 @@ RSpec.describe Hanami::Mailer::Delivery::SMTP do
       end
     end
 
+    context "when the message has a single body and an attachment" do
+      let(:message) do
+        Hanami::Mailer::Message.new(
+          from: "noreply@example.com",
+          to: "user@example.com",
+          subject: "SMTP test",
+          text_body: "Hi",
+          attachments: [
+            Hanami::Mailer::Attachment.new(
+              filename: "invoice.pdf",
+              content: "%PDF-1.4 fake",
+              content_type: "application/pdf"
+            )
+          ]
+        )
+      end
+
+      let(:mail) { smtp_delivery.call(message).response }
+
+      it "attaches the file as a non-inline sibling of the body" do
+        expect(mail.mime_type).to eq("multipart/mixed")
+
+        attachment = mail.attachments.first
+        expect(attachment.inline?).to be false
+        expect(attachment.filename).to eq("invoice.pdf")
+      end
+
+      it "preserves the text body alongside the attachment" do
+        text = mail.parts.find { |part| part.mime_type == "text/plain" }
+
+        expect(text).not_to be_nil
+        expect(text.decoded).to eq("Hi")
+      end
+    end
+
     context "when the message has an inline attachment" do
       let(:message) do
         Hanami::Mailer::Message.new(

--- a/spec/unit/delivery/smtp_spec.rb
+++ b/spec/unit/delivery/smtp_spec.rb
@@ -108,8 +108,8 @@ RSpec.describe Hanami::Mailer::Delivery::SMTP do
         expect(alternative.parts.map(&:mime_type)).to contain_exactly("text/plain", "text/html")
       end
 
-      it "keeps the attachment as a sibling of the multipart/alternative" do
-        expect(mail.parts.map(&:mime_type)).to contain_exactly("multipart/alternative", "application/pdf")
+      it "orders the bodies before the attachment under multipart/mixed" do
+        expect(mail.parts.map(&:mime_type)).to eq(["multipart/alternative", "application/pdf"])
         expect(mail.attachments.map(&:filename)).to eq(["invoice.pdf"])
       end
     end

--- a/spec/unit/delivery/smtp_spec.rb
+++ b/spec/unit/delivery/smtp_spec.rb
@@ -113,5 +113,138 @@ RSpec.describe Hanami::Mailer::Delivery::SMTP do
         expect(mail.attachments.map(&:filename)).to eq(["invoice.pdf"])
       end
     end
+
+    context "when the message has both bodies and no attachments" do
+      let(:message) do
+        Hanami::Mailer::Message.new(
+          from: "noreply@example.com",
+          to: "user@example.com",
+          subject: "SMTP test",
+          html_body: "<h1>Hi</h1>",
+          text_body: "Hi"
+        )
+      end
+
+      let(:mail) { smtp_delivery.call(message).response }
+
+      it "produces a multipart/alternative with the text and HTML parts" do
+        expect(mail.mime_type).to eq("multipart/alternative")
+        expect(mail.parts.map(&:mime_type)).to contain_exactly("text/plain", "text/html")
+        expect(mail.text_part.decoded).to eq("Hi")
+        expect(mail.html_part.decoded).to eq("<h1>Hi</h1>")
+      end
+    end
+
+    context "when the message has only an HTML body" do
+      let(:message) do
+        Hanami::Mailer::Message.new(
+          from: "noreply@example.com",
+          to: "user@example.com",
+          subject: "SMTP test",
+          html_body: "<h1>Hi</h1>"
+        )
+      end
+
+      let(:mail) { smtp_delivery.call(message).response }
+
+      it "produces a single text/html body" do
+        expect(mail.mime_type).to eq("text/html")
+        expect(mail.body.decoded).to eq("<h1>Hi</h1>")
+      end
+    end
+
+    context "when the message has only a text body" do
+      let(:message) do
+        Hanami::Mailer::Message.new(
+          from: "noreply@example.com",
+          to: "user@example.com",
+          subject: "SMTP test",
+          text_body: "Hi"
+        )
+      end
+
+      let(:mail) { smtp_delivery.call(message).response }
+
+      it "produces a single text/plain body" do
+        expect(mail.mime_type).to eq("text/plain")
+        expect(mail.body.decoded).to eq("Hi")
+      end
+    end
+
+    context "when the message has the full set of address fields and headers" do
+      let(:message) do
+        Hanami::Mailer::Message.new(
+          from: "noreply@example.com",
+          to: "user@example.com",
+          cc: "cc@example.com",
+          bcc: "bcc@example.com",
+          reply_to: "reply@example.com",
+          return_path: "bounce@example.com",
+          subject: "SMTP test",
+          text_body: "Hi",
+          headers: {"X-Custom" => "yes"}
+        )
+      end
+
+      let(:mail) { smtp_delivery.call(message).response }
+
+      it "sets every address field on the mail" do
+        expect(mail.cc).to eq(["cc@example.com"])
+        expect(mail.bcc).to eq(["bcc@example.com"])
+        expect(mail.reply_to).to eq(["reply@example.com"])
+        expect(mail.return_path).to eq("bounce@example.com")
+      end
+
+      it "sets custom headers on the mail" do
+        expect(mail["X-Custom"].value).to eq("yes")
+      end
+    end
+
+    context "when the message has no to recipient" do
+      let(:message) do
+        Hanami::Mailer::Message.new(
+          from: "noreply@example.com",
+          bcc: "bcc@example.com",
+          subject: "SMTP test",
+          text_body: "Hi"
+        )
+      end
+
+      let(:mail) { smtp_delivery.call(message).response }
+
+      it "omits the To header and keeps the bcc recipient" do
+        expect(mail.to).to be_nil
+        expect(mail.bcc).to eq(["bcc@example.com"])
+      end
+    end
+
+    context "when the message has an inline attachment" do
+      let(:message) do
+        Hanami::Mailer::Message.new(
+          from: "noreply@example.com",
+          to: "user@example.com",
+          subject: "SMTP test",
+          text_body: "Hi",
+          attachments: [
+            Hanami::Mailer::Attachment.new(
+              filename: "logo.png",
+              content: "fake-png",
+              content_type: "image/png",
+              inline: true
+            )
+          ]
+        )
+      end
+
+      let(:mail) { smtp_delivery.call(message).response }
+
+      it "marks the attachment as inline with a content id" do
+        attachment = mail.attachments.first
+
+        expect(attachment.inline?).to be true
+        expect(attachment.filename).to eq("logo.png")
+        expect(attachment.content_id).not_to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
On reviewing the open issues ahead of the v2 release, I saw this old issue from the v1 mailer: Closes https://github.com/hanami/hanami-mailer/issues/78

I checked to see if it's still an issue in v2 and it is, so here's a fix for that. 

I also refactored to make the code a bit simpler along the way, and added a bunch of specs for branches we didn't have covered. 

TIL: You can send an email with out 'to' and only 'bcc' :)