### PR TITLE
Make Result success consistent by construction

### DIFF
--- a/lib/hanami/mailer/delivery/result.rb
+++ b/lib/hanami/mailer/delivery/result.rb
@@ -57,14 +57,21 @@ module Hanami
 
         # @param message [Hanami::Mailer::Message] the prepared message
         # @param response [Object, nil] the raw response from the delivery method
-        # @param success [Boolean] whether delivery succeeded (default: true)
+        # @param success [Boolean, nil] whether delivery succeeded. Optional; when given it
+        #   must be consistent with +error+ (true only when +error+ is nil). When omitted,
+        #   success is derived from the presence of +error+.
         # @param error [Exception, nil] the exception raised, if delivery failed
         #
+        # @raise [ArgumentError] if +success+ contradicts the presence of +error+
+        #
         # @api private
-        def initialize(message:, response: nil, success: true, error: nil)
+        def initialize(message:, response: nil, success: nil, error: nil)
+          if !success.nil? && success != error.nil?
+            raise ArgumentError, "success: #{success.inspect} is inconsistent with error: #{error.inspect}"
+          end
+
           @message  = message
           @response = response
-          @success  = success
           @error    = error
         end
 
@@ -74,7 +81,16 @@ module Hanami
         #
         # @api public
         def success?
-          @success
+          error.nil?
+        end
+
+        # Returns true if delivery failed.
+        #
+        # @return [Boolean]
+        #
+        # @api public
+        def failure?
+          !success?
         end
       end
     end

--- a/lib/hanami/mailer/delivery/result.rb
+++ b/lib/hanami/mailer/delivery/result.rb
@@ -57,19 +57,11 @@ module Hanami
 
         # @param message [Hanami::Mailer::Message] the prepared message
         # @param response [Object, nil] the raw response from the delivery method
-        # @param success [Boolean, nil] whether delivery succeeded. Optional; when given it
-        #   must be consistent with +error+ (true only when +error+ is nil). When omitted,
-        #   success is derived from the presence of +error+.
-        # @param error [Exception, nil] the exception raised, if delivery failed
-        #
-        # @raise [ArgumentError] if +success+ contradicts the presence of +error+
+        # @param error [Exception, nil] the exception raised, if delivery failed. Success is
+        #   derived from its absence.
         #
         # @api private
-        def initialize(message:, response: nil, success: nil, error: nil)
-          if !success.nil? && success != error.nil?
-            raise ArgumentError, "success: #{success.inspect} is inconsistent with error: #{error.inspect}"
-          end
-
+        def initialize(message:, response: nil, error: nil)
           @message  = message
           @response = response
           @error    = error

--- a/lib/hanami/mailer/delivery/result.rb
+++ b/lib/hanami/mailer/delivery/result.rb
@@ -14,7 +14,7 @@ module Hanami
       #   if result.success?
       #     log.info "Delivered to #{result.message.to.join(', ')}"
       #   else
-      #     log.error "Delivery failed: #{result.error.message}"
+      #     log.error "Delivery failed: #{result.error}"
       #   end
       #
       # @example A third-party delivery method returning a richer result
@@ -48,17 +48,23 @@ module Hanami
         # @api public
         attr_reader :response
 
-        # The exception raised during delivery, if delivery failed.
+        # The error that occurred during delivery, if delivery failed.
         #
-        # @return [Exception, nil]
+        # This is `nil` for a successful delivery. For a failed delivery it is a truthy object
+        # describing the error. This will typically be the exception raised during delivery, but
+        # delivery methods are free to represent failures with any object that responds to `#to_s`,
+        # allowing third-party providers to surface richer error details.
+        #
+        # @return [Object, nil] an object responding to `#to_s`, or nil if delivery succeeded
         #
         # @api public
         attr_reader :error
 
         # @param message [Hanami::Mailer::Message] the prepared message
         # @param response [Object, nil] the raw response from the delivery method
-        # @param error [Exception, nil] the exception raised, if delivery failed. Success is
-        #   derived from its absence.
+        # @param error [Object, nil] the error, if delivery failed: nil, or any truthy object
+        #   responding to `#to_s` (typically the exception raised). Success is derived from its
+        #   absence.
         #
         # @api private
         def initialize(message:, response: nil, error: nil)

--- a/lib/hanami/mailer/delivery/smtp.rb
+++ b/lib/hanami/mailer/delivery/smtp.rb
@@ -37,7 +37,6 @@ module Hanami
           Result.new(
             message: message,
             response: mail,
-            success: delivery_exception.nil?,
             error: delivery_exception
           )
         end

--- a/spec/integration/delivery_result_spec.rb
+++ b/spec/integration/delivery_result_spec.rb
@@ -162,7 +162,6 @@ RSpec.describe "Delivery results" do
 
           result_class.new(
             message: message,
-            success: false,
             error: error,
             error_code: 429
           )

--- a/spec/unit/delivery/result_spec.rb
+++ b/spec/unit/delivery/result_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::Mailer::Delivery::Result do
+  subject(:result) { described_class.new(message: message, error: error) }
+
+  let(:message) { instance_double(Hanami::Mailer::Message) }
+  let(:error) { nil }
+
+  describe "#success?" do
+    context "when there is no error" do
+      it "returns true" do
+        expect(result.success?).to be true
+      end
+    end
+
+    context "when there is an error" do
+      let(:error) { StandardError.new("boom") }
+
+      it "returns false" do
+        expect(result.success?).to be false
+      end
+    end
+  end
+
+  describe "#failure?" do
+    context "when there is no error" do
+      it "returns false" do
+        expect(result.failure?).to be false
+      end
+    end
+
+    context "when there is an error" do
+      let(:error) { StandardError.new("boom") }
+
+      it "returns true" do
+        expect(result.failure?).to be true
+      end
+    end
+  end
+
+  describe ".new" do
+    context "when success: contradicts the presence of error" do
+      it "raises when success is true but an error is given" do
+        expect {
+          described_class.new(message: message, success: true, error: StandardError.new("boom"))
+        }.to raise_error(ArgumentError, /inconsistent/)
+      end
+
+      it "raises when success is false but no error is given" do
+        expect {
+          described_class.new(message: message, success: false, error: nil)
+        }.to raise_error(ArgumentError, /inconsistent/)
+      end
+    end
+
+    context "when success: is consistent with error" do
+      it "accepts success: false with an error" do
+        result = described_class.new(message: message, success: false, error: StandardError.new("boom"))
+
+        expect(result.failure?).to be true
+      end
+
+      it "accepts success: true with no error" do
+        result = described_class.new(message: message, success: true, error: nil)
+
+        expect(result.success?).to be true
+      end
+    end
+  end
+end

--- a/spec/unit/delivery/result_spec.rb
+++ b/spec/unit/delivery/result_spec.rb
@@ -37,34 +37,4 @@ RSpec.describe Hanami::Mailer::Delivery::Result do
       end
     end
   end
-
-  describe ".new" do
-    context "when success: contradicts the presence of error" do
-      it "raises when success is true but an error is given" do
-        expect {
-          described_class.new(message: message, success: true, error: StandardError.new("boom"))
-        }.to raise_error(ArgumentError, /inconsistent/)
-      end
-
-      it "raises when success is false but no error is given" do
-        expect {
-          described_class.new(message: message, success: false, error: nil)
-        }.to raise_error(ArgumentError, /inconsistent/)
-      end
-    end
-
-    context "when success: is consistent with error" do
-      it "accepts success: false with an error" do
-        result = described_class.new(message: message, success: false, error: StandardError.new("boom"))
-
-        expect(result.failure?).to be true
-      end
-
-      it "accepts success: true with no error" do
-        result = described_class.new(message: message, success: true, error: nil)
-
-        expect(result.success?).to be true
-      end
-    end
-  end
 end


### PR DESCRIPTION
`Result#success?` used to read a separately-stored `@success` flag, which could drift from `error`, i.e. there could be a "success" carrying an error, or a "failure" with none, were both representable.

[My first pass at this](669068) was enforcing the invariant: success couldn't be true if an error was present. I also added `#failure?` here for convenience.

Then we realized we could go further... by just preventing `success:` from being manually passed in at all. Inconsistent states are now *unrepresentable* rather than merely *validated*, which let the guard and its tests go away too! I think this is better, but open to feedback on whether we want to keep `success:` around as a convenience. Since it's internal, I don't think we need to, but I'm all ears.


One thing we could do here is raise an ArgumentError when `error` is not `nil` nor an `Exception`. I'm open to this but I don't think we need to be so prescriptive and just let it be duck typed. 🦆 