### PR TITLE
Add `decorate` shorthand for `expose`

### DIFF
--- a/lib/hanami/mailer.rb
+++ b/lib/hanami/mailer.rb
@@ -127,10 +127,45 @@ module Hanami
         @headers ||= DSL::Exposures.new
       end
 
-      # Define template data exposures
+      # Defines one or more values to expose to the template.
       #
-      # @param names [Array<Symbol>] exposure names
-      # @param proc [Proc] optional block for computing the value
+      # An exposure's value comes from the first of these that applies:
+      #
+      # 1. The given block (single name only).
+      # 2. An instance method matching the name.
+      # 3. The matching key in the input given to {#call}, or the `:default`
+      #    option if the input has no such key.
+      #
+      # When a block or method provides the value, its parameters determine what
+      # it receives:
+      #
+      # - Positional parameters receive other exposures' values, matched by name.
+      # - Keyword parameters receive matching keys from the input. Give them
+      #   defaults to make those input keys optional.
+      # - A keyword splat (`**input`) receives the entire input.
+      #
+      # Pass several names to expose multiple values at once; the options then
+      # apply to every named exposure. A block may only be given for a single
+      # name.
+      #
+      # @example A value computed by a block
+      #   expose :greeting do |user:|
+      #     "Hello, #{user.name}"
+      #   end
+      #
+      # @example A value from a matching instance method, or passed through from the input
+      #   expose :user
+      #
+      # @example Multiple values passed through from the input
+      #   expose :user, :order
+      #
+      # @param names [Array<Symbol>] the exposure names
+      # @param options [Hash] options applied to the exposure(s)
+      # @option options [Object] :default value to use when the input has no
+      #   matching key (pass-through exposures only)
+      # @option options [Boolean] :private exclude from the template, exposing
+      #   the value only to other exposures (defaults to false)
+      # @param block [Proc] block computing the value (single name only)
       #
       # @api public
       def expose(*names, **options, &block)

--- a/lib/hanami/mailer/view_integration.rb
+++ b/lib/hanami/mailer/view_integration.rb
@@ -3,8 +3,9 @@
 module Hanami
   class Mailer
     # Integration module for Hanami::View support.
-    # This module is included when Hanami::View is available,
-    # providing automatic view building and settings inheritance.
+    #
+    # This module is included when Hanami::View is available, providing automatic view building and
+    # settings inheritance.
     #
     # @api private
     module ViewIntegration
@@ -62,6 +63,15 @@ module Hanami
           return @default_view if defined?(@default_view)
 
           @default_view = config.integrate_view ? DefaultViewBuilder.call(self) : nil
+        end
+
+        # Defines an exposure that will be decorated with a matching view part.
+        #
+        # This is a shorthand for `expose(..., decorate: true)`.
+        #
+        # @see Mailer.expose
+        def decorate(*names, **options, &block)
+          expose(*names, **options, decorate: true, &block)
         end
       end
 

--- a/spec/integration/view_integration_spec.rb
+++ b/spec/integration/view_integration_spec.rb
@@ -91,7 +91,15 @@ RSpec.describe "View integration" do
 
     describe "exposures passed to view" do
       before do
-        write "order_mailer.html.erb", "<p>Order #<%= order_id %> for <%= customer_name %></p>"
+        write "order_mailer.html.erb",
+          "<p><%= reference %> — Order #<%= order_id %> for <%= customer.formal_name %></p>"
+
+        # Part used for a decorated exposure
+        stub_const("OrderParts::Customer", Class.new(Hanami::View::Part) {
+          def formal_name
+            "Mx #{value[:name]}"
+          end
+        })
       end
 
       let(:mailer_class) {
@@ -99,21 +107,24 @@ RSpec.describe "View integration" do
         Class.new(Hanami::Mailer) {
           config.paths = [dir]
           config.template = "order_mailer"
+          config.part_namespace = OrderParts
 
           from "noreply@example.com"
           to "user@example.com"
           subject "Order confirmation"
 
           expose :order_id
-          expose :customer_name do |customer:|
-            customer[:name]
+          expose :reference do |order_id:|
+            "REF-#{order_id}"
           end
+          decorate :customer
         }
       }
 
       it "passes all exposures to view" do
         result = mailer.deliver(order_id: 12_345, customer: {name: "Bob"})
 
+        expect(result.message.html_body).to include("REF-12345")
         expect(result.message.html_body).to include("Order #12345")
         expect(result.message.html_body).to include("Bob")
       end
@@ -121,7 +132,13 @@ RSpec.describe "View integration" do
       it "evaluates computed exposures before passing to view" do
         result = mailer.deliver(order_id: 99_999, customer: {name: "Charlie"})
 
-        expect(result.message.html_body).to include("Charlie")
+        expect(result.message.html_body).to include("REF-99999")
+      end
+
+      it "decorates a whole exposed object with a matching view part" do
+        result = mailer.deliver(order_id: 12_345, customer: {name: "Bob"})
+
+        expect(result.message.html_body).to include("Mx Bob")
       end
     end
 


### PR DESCRIPTION
`decorate` is an important new API for Hanami View 3.0. It should be available here too, given our close integration with Hanami View.

Fixes #152.