### PR TITLE
Make exposures the single source of prepared values

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,12 @@ A mailer has two body formats, `:html` and `:text`, each rendered from its own t
 Both HTML and text formats are rendered by default, producing a multipart email. Pass `format: :html` or `format: :text` to `#deliver` or `#prepare` to render a single format only.
 
 Without Hanami View, mailers still send mail — you just supply the bodies yourself (see [Custom rendering without Hanami View](#custom-rendering-without-hanami-view)).
+
 ### Dynamic headers and exposures
 
-Use header methods with blocks to compute headers dynamically based on input data. Use `expose` to prepare values for rendering via the view template (when Hanami View is available).
+Use header methods with blocks to compute headers dynamically based on input data.
+
+Use `expose` to prepare values and make them available to your headers, attachments, and delivery options, and when Hanami View is available, your view templates for rendering.
 
 ```ruby
 class UserMailer < Hanami::Mailer
@@ -106,13 +109,50 @@ The HTML and text bodies come from these templates.
 Hello, <%= user[:name] %>!
 ```
 
-Exposures and header methods both support:
+`expose` comes in a few forms:
 
-- Simple value passing: `expose :user`
-- Computed values with blocks: `expose(:total) { |order:| order[:items].sum { |item| item[:price] } }`
-- Dependencies on other exposures: `expose(:greeting) { |user:| "Hello, #{user[:name]}!" }`
-- Default values: `expose :greeting, default: "Hello"`
-- Private exposures (available to other exposures but not to templates): `expose :raw_data, private: true`
+```ruby
+# A value passed straight through from the input.
+expose :user
+
+# A value computed by a block.
+expose(:greeting) { |customer:| "Hello, #{customer[:name]}!" }
+
+# A default for optional input.
+expose :greeting, default: "Hello"
+
+# A private value: available to other exposures, headers, attachments, and delivery options, but
+# never passed to the view for rendering.
+private_expose :full_name do |first_name:, last_name:|
+  "#{first_name} #{last_name}"
+end
+```
+
+### Accessing input and exposures in blocks
+
+Mailer class methods receiving blocks (`expose`, as well as the header methods, `attachment`, and `delivery_option`) follow one rule for their parameters:
+
+- **Keyword parameters** receive matching keys from the `deliver` input. Give them defaults to make those keys optional.
+- **Positional parameters** receive exposure values, matched by name.
+
+```ruby
+class OrderMailer < Hanami::Mailer
+  from "orders@example.com"
+
+  # `customer:` comes from the same keyword arg given to `#deliver`
+  to { |customer:| customer[:email] }
+
+  # `customer:` comes from the input; `greeting` becomes an exposure
+  expose :greeting do |customer:|
+    "Hello, #{customer[:name]}!"
+  end
+
+  # `greeting` receives the value from the `:greeting` exposure above
+  subject { |greeting| greeting }
+end
+
+OrderMailer.new.deliver(customer: {name: "Alice", email: "alice@example.com"})
+```
 
 ### Standard and custom email headers
 
@@ -199,7 +239,7 @@ If a file cannot be found in any of the configured paths, a `MissingAttachmentEr
 
 ### Dynamic attachments
 
-Return one or more attachments from an `attachment` block, which processes arguments in the same way as `expose` and `header`. Use the `file` helper to create attachment objects.
+Return one or more attachments from an `attachment` block, whose parameters work [like every other block](#accessing-input-and-exposures-in-blocks). Use the `file` helper to create attachment objects.
 
 ```ruby
 class ReportMailer < Hanami::Mailer
@@ -338,7 +378,7 @@ mailer.deliver(
 
 ### Delivery options
 
-Delivery options are delivery-method-specific parameters that customize how a message is sent. They are evaluated the same way as headers and exposures, then passed through to the delivery method on the `Message` object.
+Delivery options are delivery-method-specific parameters that customize how a message is sent. Their blocks receive arguments [like every other block](#accessing-input-and-exposures-in-blocks), and the resulting options are passed through to the delivery method on the `Message` object.
 
 A third-party email service might use these for scheduled sending, priority levels, or tracking.
 
@@ -584,4 +624,3 @@ If Hanami View is installed but you don't want mailers building a view from it a
 ## License
 
 See `LICENSE` file.
-

--- a/lib/hanami/mailer.rb
+++ b/lib/hanami/mailer.rb
@@ -89,9 +89,12 @@ module Hanami
       # Can be called with:
       # - A static value: `header :from, "noreply@example.com"`
       # - A static value with proper casing: `header "X-Priority", "1"`
-      # - A proc/block: `header(:to) { |user_email:| user_email }`
+      # - A proc/block: `header(:to) { |recipient| recipient[:email] }`
       #
-      # Procs receive keyword arguments from the merged input and exposures context.
+      # A block's parameters follow the same convention as everywhere in the mailer:
+      #
+      # - Positional parameters receive exposure values, matched by name.
+      # - Keyword parameters receive matching keys from the `deliver` input.
       #
       # Header names:
       # - Symbols with underscores (e.g., :x_priority) are converted to Title-Case (X-Priority)
@@ -111,9 +114,10 @@ module Hanami
       #
       # Each method can be called with:
       # - A static value: `from "noreply@example.com"`
-      # - A proc/block: `to { |user_email:| user_email }`
+      # - A proc/block: `to { |recipient| recipient[:email] }`
       #
-      # Procs receive keyword arguments from the merged input and exposures context.
+      # As with {#header}, a block's positional parameters receive exposure values and its keyword
+      # parameters receive matching keys from the `deliver` input.
       #
       # @api public
       STANDARD_HEADERS.each do |field_name|
@@ -163,8 +167,9 @@ module Hanami
       # @param options [Hash] options applied to the exposure(s)
       # @option options [Object] :default value to use when the input has no
       #   matching key (pass-through exposures only)
-      # @option options [Boolean] :private exclude from the template, exposing
-      #   the value only to other exposures (defaults to false)
+      # @option options [Boolean] :private withhold from the view, while keeping
+      #   the value available as a dependency to other exposures, headers,
+      #   attachments, and delivery options (defaults to false)
       # @param block [Proc] block computing the value (single name only)
       #
       # @api public
@@ -176,12 +181,29 @@ module Hanami
         end
       end
 
+      # Defines one or more private exposures.
+      #
+      # A private exposure is computed and stays available as a dependency to other exposures, and
+      # to the mailer's headers, attachments, and delivery options, but is never passed to the view
+      # for rendering. This is a shorthand for `expose(..., private: true)`.
+      #
+      # @see #expose
+      #
+      # @api public
+      def private_expose(*names, **options, &block)
+        expose(*names, **options, private: true, &block)
+      end
+
       # @api private
       def exposures
         @exposures ||= DSL::Exposures.new
       end
 
       # Define an attachment
+      #
+      # An attachment block returns one or more attachment objects (use the {#file} helper). As with
+      # {#header}, its positional parameters receive exposure values and its keyword parameters
+      # receive matching keys from the `deliver` input.
       #
       # @param name_or_filename [Symbol, String] method name or static filename
       # @param proc [Proc] optional block for computing attachment
@@ -202,6 +224,9 @@ module Hanami
       # to customize how a message is sent. For example, a third-party email service
       # might support scheduled sending, priority levels, or tracking options.
       #
+      # As with {#header}, a block's positional parameters receive exposure values and its keyword
+      # parameters receive matching keys from the `deliver` input.
+      #
       # @param name [Symbol] the option name
       # @param value [Object, nil] optional static value
       # @param block [Proc] optional block for computing the value
@@ -211,9 +236,14 @@ module Hanami
       # @example Static value
       #   delivery_option :track_opens, true
       #
-      # @example Dynamic value with block
+      # @example Value computed from the input (keyword parameter)
       #   delivery_option :send_at do |scheduled_time:|
       #     scheduled_time
+      #   end
+      #
+      # @example Value computed from an exposure (positional parameter)
+      #   delivery_option :priority do |user_type|
+      #     user_type == "premium" ? "high" : "normal"
       #   end
       def delivery_option(name, value = nil, &block)
         delivery_options.add(name, block, default: value)
@@ -277,38 +307,37 @@ module Hanami
     #
     # @api public
     def prepare(headers: {}, attachments: nil, format: nil, **input)
-      # Collect header overrides
-      header_overrides = headers.compact
-
-      # Evaluate exposures
+      # Evaluate exposures as our "locals". These will be provided as the _depdenencies_ (available
+      # via positional params) to all our other class-level exposure-like APIs: headers,
+      # attachments, and delivery options.
       locals = self.class.exposures.bind(self).call(input)
 
-      # Merge input with evaluated locals for use in header evaluation
-      context = input.merge(locals)
+      # Evaluate class-level headers, giving precdence to headers given as explicit arguments.
+      header_overrides = headers.compact
+      headers = self.class.headers
+        .bind(self)
+        .call(input, dependencies: locals)
+        .merge(header_overrides)
 
-      # Evaluate headers (from, to, cc, bcc, reply_to, return_path, subject, and custom headers)
-      headers = self.class.headers.bind(self).call(context)
+      # Extract custom headers and normalize their header names to proper casing.
+      custom_headers = headers
+        .reject { |key, _| STANDARD_HEADERS.include?(key) }
+        .transform_keys { |key| normalize_header_name(key) }
 
-      # Merge with overrides, giving precedence to explicit arguments
-      headers = headers.merge(header_overrides)
+      # Render bodies. Private exposures are available to the methods above as dependencies, but are
+      # withheld from the view.
+      html_body, text_body = render(self.class.exposures.reject_private(locals), format:)
 
-      # Separate standard headers from custom headers
-      custom_headers = headers.reject { |key, _| STANDARD_HEADERS.include?(key) }
-
-      # Normalize custom header names to proper casing
-      normalized_custom_headers = custom_headers.transform_keys { |key| normalize_header_name(key) }
-
-      # Render body
-      html_body, text_body = render(input, format:)
-
-      # Evaluate class-level attachments and merge with runtime attachments
+      # Evaluate class-level attachments and merge with runtime attachments.
       runtime_attachments = attachments
       attachments = self.class.attachments
-        .bind(self, context)
+        .bind(self)
+        .call(input, dependencies: locals)
         .concat(runtime_attachments)
         .to_a
 
-      delivery_options = self.class.delivery_options.bind(self).call(context)
+      # Evaluate delivery options.
+      delivery_options = self.class.delivery_options.bind(self).call(input, dependencies: locals)
 
       # Build message
       Message.new(
@@ -322,7 +351,7 @@ module Hanami
         html_body:,
         text_body:,
         attachments: attachments,
-        headers: normalized_custom_headers,
+        headers: custom_headers,
         delivery_options:
       )
     end

--- a/lib/hanami/mailer/dsl/attachments.rb
+++ b/lib/hanami/mailer/dsl/attachments.rb
@@ -9,8 +9,8 @@ module Hanami
       class Attachments
         attr_reader :definitions
 
-        def initialize
-          @definitions = []
+        def initialize(definitions = [])
+          @definitions = definitions
         end
 
         private def initialize_copy(source)
@@ -22,10 +22,17 @@ module Hanami
           definitions << Attachment.new(name_or_filename, proc, **options)
         end
 
-        # Binds all definitions to a mailer instance and evaluates them, returning an
-        # {AttachmentSet} of {Attachment} instances.
-        def bind(obj, input)
-          attachments = definitions.flat_map { |definition| definition.bind(obj).call(input) }
+        # Returns a copy with every definition bound to the mailer instance.
+        def bind(obj)
+          self.class.new(definitions.map { |definition| definition.bind(obj) })
+        end
+
+        # Evaluates the bound definitions, returning an {AttachmentSet} of {Attachment} instances.
+        #
+        # Each definition's positional parameters resolve against `dependencies` (the mailer's
+        # exposure values); its keyword parameters resolve against `input` (the raw `deliver` input).
+        def call(input, dependencies: {})
+          attachments = definitions.flat_map { |definition| definition.call(input, dependencies) }
 
           AttachmentSet.new(attachments)
         end
@@ -65,11 +72,20 @@ module Hanami
         end
 
         # Evaluates the attachment definition and returns an array of Attachment objects.
-        def call(input)
-          Array(@callable.call(input)).each { ensure_attachment(_1) }
+        #
+        # Positional parameters resolve against `dependencies` (the mailer's exposure values);
+        # keyword parameters resolve against `input`.
+        def call(input, dependencies = {})
+          Array(@callable.call(input, *dependency_args(dependencies))).each { ensure_attachment(_1) }
         end
 
         private
+
+        def dependency_args(dependencies)
+          return [] unless @callable.respond_to?(:dependency_names)
+
+          @callable.dependency_names.map { |name| dependencies.fetch(name) }
+        end
 
         def static_callable
           filename = @name_or_filename

--- a/lib/hanami/mailer/dsl/exposures.rb
+++ b/lib/hanami/mailer/dsl/exposures.rb
@@ -60,27 +60,41 @@ module Hanami
           copy
         end
 
-        def call(input)
-          # Avoid performance cost of tsorting when we don't need it
-          names = dependencies? ? tsort : exposures.keys
+        # Evaluates each exposure and returns a hash of their values.
+        #
+        # By default each exposure's positional parameters resolve against its sibling exposures in
+        # this collection (the values accumulate as the collection is evaluated, ordered by tsort).
+        #
+        # When `dependencies` is given, positional parameters resolve against those instead, and no
+        # sibling resolution (or tsort) takes place. This is how the mailer collections like headers
+        # and delivery options consume the mailer's exposures as their one shared dependency graph.
+        def call(input, dependencies: nil)
+          ordered_evaluation_keys(dependencies).each_with_object({}) { |name, memo|
+            next unless (exposure = self[name])
 
-          names
-            .each_with_object({}) { |name, memo|
-              next unless (exposure = self[name])
+            value = exposure.(input, dependencies || memo)
+            value = yield(value, exposure) if block_given?
 
-              value = exposure.(input, memo)
-              value = yield(value, exposure) if block_given?
+            memo[name] = value
+          }
+        end
 
-              memo[name] = value
-            }
-            .tap { |hsh|
-              names.each do |key|
-                hsh.delete(key) if self[key].private?
-              end
-            }
+        # Removes private exposures from a hash of evaluated values.
+        #
+        # Private exposures are computed and stay available as positional dependencies — to other
+        # exposures, and to the mailer's headers, attachments, and delivery options — but they are
+        # never passed to the view for rendering. This filters them out for that final step.
+        def reject_private(values)
+          values.reject { |name, _| self[name]&.private? }
         end
 
         private
+
+        # With external dependencies, there are no sibling dependencies to order, so tsort is only
+        # needed when resolving siblings within our own collection.
+        def ordered_evaluation_keys(dependencies)
+          dependencies.nil? && dependencies? ? tsort : exposures.keys
+        end
 
         def dependencies? = @has_dependencies
 

--- a/lib/hanami/mailer/view_integration.rb
+++ b/lib/hanami/mailer/view_integration.rb
@@ -184,12 +184,14 @@ module Hanami
 
               self.config.template = view_template if view_template
 
+              # Exposures are evaluated once, by the mailer, which passes their values to the view.
+              # The view only needs to pass each value through to the template (decorating it as
+              # required), so the procs are dropped here. Private exposures are internal to the
+              # mailer's evaluation and are not passed to the view at all.
               view_exposures.each do |name, exposure|
-                if exposure.proc
-                  expose(name, **exposure.options, &exposure.proc)
-                else
-                  expose(name, **exposure.options)
-                end
+                next if exposure.private?
+
+                expose(name, **exposure.options)
               end
             end
 

--- a/spec/integration/attachments_spec.rb
+++ b/spec/integration/attachments_spec.rb
@@ -54,6 +54,33 @@ RSpec.describe "Attachments" do
       end
     end
 
+    describe "depending on exposures" do
+      let(:mailer_class) do
+        Class.new(Hanami::Mailer) do
+          from "noreply@example.com"
+          to "user@example.com"
+          subject "Invoice"
+
+          expose :reference do |invoice_number:|
+            "INV-#{invoice_number}"
+          end
+
+          # A positional parameter resolves the `reference` exposure.
+          attachment do |reference|
+            file("#{reference}.pdf", "PDF content for #{reference}")
+          end
+        end
+      end
+
+      it "resolves positional parameters against exposures" do
+        result = mailer.deliver(invoice_number: 12_345)
+
+        attachment = result.message.attachments.first
+        expect(attachment.filename).to eq("INV-12345.pdf")
+        expect(attachment.content).to eq("PDF content for INV-12345")
+      end
+    end
+
     describe "multiple attachments" do
       let(:mailer_class) do
         Class.new(Hanami::Mailer) do

--- a/spec/integration/delivery_options_spec.rb
+++ b/spec/integration/delivery_options_spec.rb
@@ -121,7 +121,8 @@ RSpec.describe "Delivery options" do
           user[:premium] ? "premium" : "standard"
         end
 
-        delivery_option :priority do |user_type:|
+        # Depend on the `user_type` exposure
+        delivery_option :priority do |user_type|
           user_type == "premium" ? "high" : "normal"
         end
       end

--- a/spec/integration/headers_spec.rb
+++ b/spec/integration/headers_spec.rb
@@ -169,11 +169,12 @@ RSpec.describe "Headers" do
           user[:vip] ? "high" : "normal"
         end
 
-        header(:x_priority) do |priority_level:|
+        # Positional parameters resolve exposures; `user` and `priority_level` are both exposures.
+        header(:x_priority) do |priority_level|
           priority_level == "high" ? "1" : "3"
         end
 
-        header(:x_user_tier) do |user:|
+        header(:x_user_tier) do |user|
           user[:vip] ? "premium" : "standard"
         end
       }
@@ -187,6 +188,55 @@ RSpec.describe "Headers" do
       result = mailer.deliver(user: {name: "Bob", vip: false})
       expect(result.message.headers["X-Priority"]).to eq("3")
       expect(result.message.headers["X-User-Tier"]).to eq("standard")
+    end
+  end
+
+  describe "separating input from exposures" do
+    let(:mailer_class) {
+      Class.new(Hanami::Mailer) {
+        from "noreply@example.com"
+        to "user@example.com"
+        subject "Test"
+
+        # An exposure that transforms the like-named input, so the two are distinguishable.
+        expose :name do |name:|
+          name.upcase
+        end
+
+        # Keyword parameters read the raw input; positional parameters read the exposure.
+        header(:x_from_input) { |name:| name }
+        header(:x_from_exposure) { |name| name }
+      }
+    }
+
+    it "reads input via keyword parameters and exposures via positional parameters" do
+      result = mailer.deliver(name: "alice")
+
+      expect(result.message.headers["X-From-Input"]).to eq("alice")
+      expect(result.message.headers["X-From-Exposure"]).to eq("ALICE")
+    end
+  end
+
+  describe "depending on private exposures" do
+    let(:mailer_class) {
+      Class.new(Hanami::Mailer) {
+        from "noreply@example.com"
+        to "user@example.com"
+        subject "Test"
+
+        # Private exposures are withheld from the view, but remain available to headers.
+        private_expose :full_name do |first_name:, last_name:|
+          "#{first_name} #{last_name}"
+        end
+
+        header(:x_name) { |full_name| full_name }
+      }
+    }
+
+    it "resolves private exposures as positional dependencies" do
+      result = mailer.deliver(first_name: "Ada", last_name: "Lovelace")
+
+      expect(result.message.headers["X-Name"]).to eq("Ada Lovelace")
     end
   end
 

--- a/spec/integration/mailer_spec.rb
+++ b/spec/integration/mailer_spec.rb
@@ -67,8 +67,8 @@ RSpec.describe "Basic mail delivery" do
     let(:mailer_class) {
       Class.new(Hanami::Mailer) {
         from "noreply@example.com"
-        to { |recipient_email:| recipient_email }
-        subject { |greeting:, recipient_name:| "#{greeting}, #{recipient_name}!" }
+        to { |recipient_email| recipient_email }
+        subject { |greeting, recipient_name| "#{greeting}, #{recipient_name}!" }
 
         expose :user
         expose :recipient_name do |user:|

--- a/spec/integration/view_integration_spec.rb
+++ b/spec/integration/view_integration_spec.rb
@@ -142,6 +142,44 @@ RSpec.describe "View integration" do
       end
     end
 
+    describe "private exposures" do
+      before do
+        write "receipt_mailer.html.erb", "<p>Total: <%= total %></p>"
+      end
+
+      let(:mailer_class) {
+        dir = templates_dir
+        Class.new(Hanami::Mailer) {
+          config.paths = [dir]
+          config.template = "receipt_mailer"
+
+          from "noreply@example.com"
+          to "user@example.com"
+          subject "Receipt"
+
+          expose :total do |subtotal|
+            subtotal + 5
+          end
+
+          private_expose :subtotal do |items:|
+            items.sum
+          end
+        }
+      }
+
+      it "exposes the value to other exposures but not to the template" do
+        result = mailer.deliver(items: [3, 7])
+
+        expect(result.message.html_body).to include("Total: 15")
+      end
+
+      it "is not passed to the template" do
+        write "receipt_mailer.html.erb", "<p><%= subtotal %></p>"
+
+        expect { mailer.deliver(items: [3, 7]) }.to raise_error(NameError)
+      end
+    end
+
     describe "template inference" do
       before do
         write "mailers/notification_mailer.html.erb", "<p>Notification content</p>"
@@ -358,6 +396,37 @@ RSpec.describe "View integration" do
 
       expect(result.message.html_body).to eq("<h1>Hello, Alice!</h1>")
       expect(result.message.text_body).to eq("Hello, Alice!")
+    end
+
+    context "with computed and private exposures" do
+      let(:view) {
+        Class.new {
+          def call(format:, **input)
+            "greeting=#{input[:greeting]} secret=#{input[:secret].inspect}"
+          end
+        }.new
+      }
+
+      let(:mailer_class) {
+        Class.new(Hanami::Mailer) {
+          from "noreply@example.com"
+          to "user@example.com"
+          subject "Custom view email"
+
+          expose :greeting do |name:|
+            "Hello #{name}"
+          end
+          private_expose :secret
+        }
+      }
+
+      it "passes evaluated exposures, not raw input, to the injected view" do
+        result = mailer.deliver(name: "Alice", secret: "shh")
+
+        # The computed exposure is evaluated, and the private exposure is withheld, even though the
+        # injected view does not evaluate exposures itself.
+        expect(result.message.html_body).to eq("greeting=Hello Alice secret=nil")
+      end
     end
   end
 

--- a/spec/unit/dsl/exposures_spec.rb
+++ b/spec/unit/dsl/exposures_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe Hanami::Mailer::DSL::Exposures do
     end
 
     describe "private exposures" do
-      it "removes private exposures from result" do
+      it "includes private exposures in the result" do
         exposures = described_class.new
         exposures.add(:user)
         exposures.add(:internal, nil, private: true)
@@ -219,10 +219,10 @@ RSpec.describe Hanami::Mailer::DSL::Exposures do
 
         expect(result.key?(:user)).to be true
         expect(result.key?(:derived)).to be true
-        expect(result.key?(:internal)).to be false
+        expect(result.key?(:internal)).to be true
       end
 
-      it "still allows private exposures as dependencies" do
+      it "allows private exposures as dependencies" do
         exposures = described_class.new
         exposures.add(:multiplier, nil, private: true)
         exposures.add(:value)
@@ -232,8 +232,19 @@ RSpec.describe Hanami::Mailer::DSL::Exposures do
         bound = exposures.bind(context)
         result = bound.call({multiplier: 3, value: 10})
 
-        expect(result).to eq({value: 10, result: 30})
-        expect(result.key?(:multiplier)).to be false
+        expect(result).to eq({multiplier: 3, value: 10, result: 30})
+      end
+    end
+
+    describe "#reject_private" do
+      it "removes private exposures from a values hash, leaving the rest" do
+        exposures = described_class.new
+        exposures.add(:user)
+        exposures.add(:internal, nil, private: true)
+
+        result = exposures.reject_private({user: "Alice", internal: "secret"})
+
+        expect(result).to eq({user: "Alice"})
       end
     end
 


### PR DESCRIPTION
Rework exposures to become the mailer's single source of prepared values, shared by every block-based DSL as well as the view, evaluated exactly once.

Previously, mailer-level exposures were basically just sugar for `Hanami::View`, and quite compromised: they only reached the auto-built view, were re-evaluated several times per delivery, never reached injected custom views, and were not available to the header/attachment/delivery-option DSLs.

Now, all block-based methods follow the same rules for their arguments: exposures are available via positional params, and input via keyword params. This does mean that header-to-header and delivery option-to-option block dependencies are no longer possible, but this was not an expected use case, and shared exposures can fulfil the same purpose, with a simpler model for the user to understand (a single shared set of values).

This also fixes some shortcomings in the previous design:

- Exposure procs are evaluated just once. Previously the auto-built view would recmopute them. Now it receives the computed values and only needs to decorates (if required).
- Exposures now reach injected/custom views. Previously the body was rendered from the raw input only, so the computed values from exposures never went anyway.
- Private exposures are available to the other block-based DSL methods. These are stripped only before being passed for rendering.