### PR TITLE
Fix nested attachment paths leaking into delivered email

### DIFF
--- a/lib/hanami/mailer/attachment.rb
+++ b/lib/hanami/mailer/attachment.rb
@@ -66,7 +66,9 @@ module Hanami
         def from_file(filename, attachment_paths:, inline: false)
           content = read_attachment_file(filename, attachment_paths)
 
-          new(filename:, content:, inline:)
+          # A nested name (e.g. "foo/bar.pdf") is resolved via the search paths, but only its
+          # basename should reach the recipient as the attachment's filename and content-id.
+          new(filename: File.basename(filename), content:, inline:)
         end
 
         private

--- a/spec/fixtures/attachments/nested/manual.pdf
+++ b/spec/fixtures/attachments/nested/manual.pdf
@@ -1,0 +1,1 @@
+Nested manual content

--- a/spec/integration/attachments_spec.rb
+++ b/spec/integration/attachments_spec.rb
@@ -307,6 +307,55 @@ RSpec.describe "Attachments" do
         end
       end
 
+      context "with a nested filename" do
+        let(:mailer_class) do
+          dir = attachment_dir
+          Class.new(Hanami::Mailer) do
+            from "noreply@example.com"
+            to "user@example.com"
+            subject "Manual"
+
+            config.attachment_paths = [dir]
+
+            attachment "nested/manual.pdf"
+          end
+        end
+
+        it "finds the file via the search path but names the attachment by its basename" do
+          result = mailer.deliver
+
+          expect(result.message.attachments.size).to eq(1)
+
+          attachment = result.message.attachments.first
+          expect(attachment.filename).to eq("manual.pdf")
+          expect(attachment.content).to eq("Nested manual content")
+        end
+      end
+
+      context "with an inline nested filename" do
+        let(:mailer_class) do
+          dir = attachment_dir
+          Class.new(Hanami::Mailer) do
+            from "noreply@example.com"
+            to "user@example.com"
+            subject "Manual"
+
+            config.attachment_paths = [dir]
+
+            attachment "nested/manual.pdf", inline: true
+          end
+        end
+
+        it "uses the basename as the content_id, not the nested path" do
+          result = mailer.deliver
+
+          attachment = result.message.attachments.first
+          expect(attachment.inline?).to be(true)
+          expect(attachment.filename).to eq("manual.pdf")
+          expect(attachment.content_id).to eq("manual.pdf")
+        end
+      end
+
       context "when file is not found in attachment_paths" do
         let(:mailer_class) do
           dir = attachment_dir


### PR DESCRIPTION
`Attachment.from_file` now uses `File.basename`, so an attachment specified via a fully path (e.g. `"foo/bar.pdf"`) no longer leaks the directory into the attachment filename or inline content-id.