### PR TITLE
Add `Mailer#preview` convenience method

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,8 +555,17 @@ smtp.call(message)
 
 Delivery methods expose a `preview` hook that returns a prepared message without sending it. The default (and test) delivery method returns the message unchanged; a third-party delivery method can override `preview` to apply service-specific logic, such as resolving a template through a remote API.
 
+Use `#preview` to prepare the message and run it through the delivery method's hook in one step. It takes the same arguments as `#deliver` and `#prepare`:
+
 ```ruby
 mailer = WelcomeMailer.new
+
+preview = mailer.preview(user: {name: "Alice", email: "alice@example.com"})
+```
+
+When you already hold a prepared message, you can call the delivery method's hook directly instead:
+
+```ruby
 message = mailer.prepare(user: {name: "Alice", email: "alice@example.com"})
 
 preview = mailer.delivery_method.preview(message)

--- a/lib/hanami/mailer.rb
+++ b/lib/hanami/mailer.rb
@@ -294,6 +294,25 @@ module Hanami
       delivery_method.call(message)
     end
 
+    # Previews the email without delivering it
+    #
+    # Builds the message and passes it to the delivery method's `preview` hook, returning whatever
+    # that returns. The default (and test) delivery method returns the message unchanged; a
+    # third-party delivery method can override `preview` to apply service-specific logic.
+    #
+    # @param headers [Hash] optional header overrides (from, to, cc, bcc, reply_to, return_path, subject)
+    # @param attachments [Array<Hash, Attachment>, nil] optional runtime attachments
+    # @param format [Symbol, nil] optional format to render (:html or :text)
+    # @param input [Hash] input data for exposures and rendering
+    #
+    # @return [Message]
+    #
+    # @api public
+    def preview(headers: {}, attachments: nil, format: nil, **input)
+      message = prepare(headers:, attachments:, format:, **input)
+      delivery_method.preview(message)
+    end
+
     # rubocop:disable Metrics/AbcSize
 
     # Build the message without delivering it

--- a/spec/integration/mailer_spec.rb
+++ b/spec/integration/mailer_spec.rb
@@ -98,6 +98,40 @@ RSpec.describe "Basic mail delivery" do
     end
   end
 
+  describe "#preview" do
+    # A delivery method whose preview hook transforms the message, to demonstrate how #preview
+    # prepares the message and routes it through the hook (rather than just calling #prepare).
+    let(:delivery_method) {
+      Class.new {
+        def preview(message)
+          Hanami::Mailer::Message.new(**message.to_h.merge(subject: "[PREVIEW] #{message.subject}"))
+        end
+      }.new
+    }
+
+    let(:mailer) { mailer_class.new(delivery_method:) }
+
+    let(:mailer_class) {
+      Class.new(Hanami::Mailer) {
+        from "noreply@example.com"
+        to { |user:| user[:email] }
+        subject { |user:| "Welcome, #{user[:name]}!" }
+
+        expose :user
+      }
+    }
+
+    it "prepares the message, forwards its arguments, and runs it through the delivery method's preview hook" do
+      message = mailer.preview(
+        user: {name: "Alice", email: "alice@example.com"},
+        attachments: [Hanami::Mailer.file("note.txt", "hi")]
+      )
+
+      expect(message.subject).to eq "[PREVIEW] Welcome, Alice!"
+      expect(message.attachments.map(&:filename)).to eq ["note.txt"]
+    end
+  end
+
   describe "error handling" do
     describe "missing recipient" do
       let(:mailer_class) {


### PR DESCRIPTION
Rather than having to get the delivery_method first and then call `#preview` on it (which you can still do), this allows you to call it directly on the mailer, as a full counterpart to `#deliver` and `#prepare`.